### PR TITLE
Hide the login box by default and only show for private repo

### DIFF
--- a/platform/public/index.html
+++ b/platform/public/index.html
@@ -16,7 +16,7 @@
 <body class="h-100" onresize="fit()" onload="fit();updateGutterVisibility();">
     <div id="preloader"><img src="images/preloader.gif" width="100px"></div>
 
-    <div id="login" style="display:inline">
+    <div id="login" style="display:none">
         <h2>Login</h2>
         <p> 
             <button id="btnlogin" class="loginbutton" type="button" onclick="">Sign in with github</button> <br>

--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -60,6 +60,8 @@ if (!urlParamPrivateRepo()){
     // Public repo so no need to authenticate
     initialiseActivity();
     PlaygroundUtility.hideLogin();
+} else {
+    PlaygroundUtility.showLogin();
 }
 
 document.getElementById("btnlogin").onclick= async () => {

--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -59,7 +59,7 @@ document.getElementById("btnnologin").onclick= () => {
 if (!urlParamPrivateRepo()){
     // Public repo so no need to authenticate
     initialiseActivity();
-    PlaygroundUtility.hideLogin();
+    
 } else {
     PlaygroundUtility.showLogin();
 }


### PR DESCRIPTION
Hide the login box by default and only show it when a private repo is given. This prevents the login box's brief display when loading a private repo mdenet/educationplatform-docker#2.