### PR TITLE
Add panel definition for generated code

### DIFF
--- a/platform/public/common/utility.json
+++ b/platform/public/common/utility.json
@@ -40,7 +40,20 @@
     
                     "icon": "problems"
     
+                },
+
+                {
+    
+                    "id": "code",
+    
+                    "name": "code",
+                    
+                    "panelclass": "OutputPanel",
+    
+                    "icon": "editor"
+    
                 }
+
             ]
         }
     } 


### PR DESCRIPTION
The standard panel definitions only have one `OutputPanel`, and it seems to be for a "Problems" view (e.g. for EVL or OCL). It'd be good to have a panel definition for generated code, as that scenario could be quite common.