### PR TITLE
Clear notifications for activities on handling a response and added icon

### DIFF
--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -664,7 +664,7 @@ function handleResponseActionFunction(action, requestPromise){
             
             if (response.editorUrl) {
                 // Language workbench
-                longNotification("Building editor...");
+                longNotification("Building editor");
                 checkEditorReady( response.editorStatusUrl, response.editorUrl, action.source.editorPanel, action.source.editorActivity);
                 
 
@@ -808,18 +808,22 @@ function runAction(source, sourceButton) {
     longNotification("Executing program");
 }
 
+function notification(title, message, cls="light"){
+    const crossIcon = "<div class=\"default-icon-cross\" style=\"float:right\"></div>"
+    Metro.notify.create(crossIcon + "<b>"  + title + "</b>" + "<br>" + message + "<br>", null, {keepOpen: true, cls: cls, width: 300});
+}
 
 function longNotification(title, cls="light") {
-    Metro.notify.create( "<div class=\"default-icon-cross\" style=\"float:right\"></div>" + "<b>" + title + "...</b>" + "<br>This may take a few seconds to complete if the back end is not warmed up.", null, {keepOpen: true, cls: cls, width: 300});
+    notification(title + "...", "This may take a few seconds to complete if the back end is not warmed up.", cls);
 }
 
 function successNotification(message, cls="light") {
-    Metro.notify.create("<div class=\"default-icon-cross\" style=\"float:right\"></div>" + "<b>Success:</b> "+ message + "<br>", null, {keepOpen: true, cls: cls, width: 300});
+    notification("Success:", message, cls);
 }
 
 function errorNotification(message) {
     console.log("ERROR: " + message);
-    Metro.notify.create( "<div class=\"default-icon-cross\" style=\"float:right\"></div>" + "<b>Error:</b> "+ message + "<br>", null, {keepOpen: true, cls: "bg-red fg-white", width: 300});
+    notification("Error:", message, "bg-red fg-white");
 }
 
 

--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -645,6 +645,8 @@ function handleResponseActionFunction(action, requestPromise){
         var response = JSON.parse(responseText);
         var outputPanel = panels.find( pn => pn.id ==  action.output.id);
 
+        Metro.notify.killAll();
+
         if (response.hasOwnProperty("error")) {
             consolePanel.setError(response.error);
         } else {
@@ -662,7 +664,6 @@ function handleResponseActionFunction(action, requestPromise){
             
             if (response.editorUrl) {
                 // Language workbench
-                Metro.notify.killAll();
                 longNotification("Building editor...");
                 checkEditorReady( response.editorStatusUrl, response.editorUrl, action.source.editorPanel, action.source.editorActivity);
                 
@@ -737,8 +738,6 @@ function handleResponseActionFunction(action, requestPromise){
             }
 
         }
-
-        //Metro.notify.killAll();
     });
 
 }
@@ -811,16 +810,16 @@ function runAction(source, sourceButton) {
 
 
 function longNotification(title, cls="light") {
-    Metro.notify.create("<b>" + title + "...</b><br>This may take a few seconds to complete if the back end is not warmed up.", null, {keepOpen: true, cls: cls, width: 300});
+    Metro.notify.create( "<div class=\"default-icon-cross\" style=\"float:right\"></div>" + "<b>" + title + "...</b>" + "<br>This may take a few seconds to complete if the back end is not warmed up.", null, {keepOpen: true, cls: cls, width: 300});
 }
 
 function successNotification(message, cls="light") {
-    Metro.notify.create("<b>Success:</b> "+ message +"<br>", null, {keepOpen: true, cls: cls, width: 300});
+    Metro.notify.create("<div class=\"default-icon-cross\" style=\"float:right\"></div>" + "<b>Success:</b> "+ message + "<br>", null, {keepOpen: true, cls: cls, width: 300});
 }
 
 function errorNotification(message) {
     console.log("ERROR: " + message);
-    Metro.notify.create("<b>Error:</b> "+ message +"<br>", null, {keepOpen: true, cls: "bg-red fg-white", width: 300});
+    Metro.notify.create( "<div class=\"default-icon-cross\" style=\"float:right\"></div>" + "<b>Error:</b> "+ message + "<br>", null, {keepOpen: true, cls: "bg-red fg-white", width: 300});
 }
 
 


### PR DESCRIPTION
Clear notifications for activities on handling a response and added cross icon to notifications to indicate that they can be closed.

To fix - https://github.com/mdenet/educationplatform/issues/98

![notification_with_cross](https://github.com/mdenet/educationplatform/assets/32113205/5d73fc7a-84b5-42aa-9bce-6944df4a276c)
