### PR TITLE
Added support for the display of tool console output and output

### DIFF
--- a/platform/schemas/action.schema.json
+++ b/platform/schemas/action.schema.json
@@ -27,6 +27,10 @@
         "output": {
             "description": "Panel id where the tool function return will be displayed.",
             "type": "string"
+        },
+        "outputConsole": {
+            "description": "Panel id where the toolfunction console output will be displayed.",
+            "type": "string"
         }
     },
     "required": ["source", "sourceButton", "parameters", "output"]

--- a/platform/src/ActivityManager.js
+++ b/platform/src/ActivityManager.js
@@ -69,6 +69,7 @@ class ActivityManager {
             }
             
             action.output = this.resolvePanelReference(activityId, action.output);
+            action.outputConsole = this.resolvePanelReference(activityId, action.outputConsole);
         }
     }
 


### PR DESCRIPTION
To support simultaneous display of output from toolfunction as well as another output type, added optional outputConsole in config file actions panel mapping so that a console panel can be specified. Removed outdated todo for handling language workbench editor.

Updated documentation mdenet/educationplatform.wiki@e0e1d4552fd147cf5d2f32b1229e8c7880f38a7b on branch `80-output-from-a-tool-function-is-not-displayed-in-a-console-panel`.