### PR TITLE
Add support for multifile output

### DIFF
--- a/platform/src/OutputPanel.js
+++ b/platform/src/OutputPanel.js
@@ -29,6 +29,10 @@ class OutputPanel extends ModelPanel {
         }
         this.addButtons(buttons);
 
+	if (this.language == "multi") {
+	  this.createFileSelector();
+	}
+
         this.getEditor().getSession().setMode("ace/mode/" + outputLanguage.toLowerCase());
     }
 
@@ -103,24 +107,22 @@ class OutputPanel extends ModelPanel {
         var root = super.createElement();
         root.setAttribute("style", "padding: 0px");
 
-        // TODO add support for multiple files, create selector here.
-
         return root;
     }
 
     /**
      *  Adds the file selection dropdown to the panel on the page
      */
-    createFileSelector(){
-
+    createFileSelector() {
         var select = document.createElement("select");
 
         select.setAttribute("data-role", "select");
-        select.setAttribute("data-on-item-select", this, id + "Panel.generatedFileSelected()");
+        select.setAttribute("data-on-item-select", `panels.find((p) => p.id==="${this.id}").generatedFileSelected()`);
         select.setAttribute("id", "generatedFiles");
         select.setAttribute("style","width:100%");
+
+        var root = this.getElement();
         root.insertBefore(select, root.children[0]);
-        console.log(this.select);
     }
 
 }


### PR DESCRIPTION
I have a more in-depth example for the "Dev" side of the Annual Symposium tutorial, involving EGX. The EGX tool function returns a JSON with potentially multiple generated files, like this:

```json
{
    "generatedFiles": [
        {
            "path": "../gradle/lib/src/main/java/org/mdenet/HelloWorld.java",
            "content": "package org.mdenet;\n\npublic class HelloWorld {\n}\n"
        }
    ]
}
```

The problem is that showing this correctly requires implementing the multiple-output support that got dropped during the refactoring from the Epsilon Playground to the MDENet EP. 

This PR adds it back for any panel definition that uses `multi` as its `language`, like this one:

```json
{
  "id": "multicode",
  "name": "code",
  "panelclass": "OutputPanel",
  "icon": "editor",
  "language": "multi"
}
```

The panel definition would need to be in the `tools.json` of the relevant tool server.

With this and the latest version of the Epsilon `playground-micronaut` project, I can reproduce our EGX example:

![image](https://github.com/mdenet/educationplatform/assets/46504/e7372181-d3a8-4d2a-975e-2034ab537878)
