### PR TITLE
Add support for customising the URL to the token server

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -12,10 +12,9 @@ COPY package*.json ./
 
 COPY . .
 
-RUN npm install; npm run build
+ARG TOKEN_SERVER_URL=http://127.0.0.1:10000
 
-
-
+RUN npm install && npm run build -- --env tokenServerUrl=${TOKEN_SERVER_URL} && npm run package
 
 FROM nginx:1.23
 

--- a/platform/package.json
+++ b/platform/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.1",
   "scripts": {
     "test": "karma start",
-    "build": "webpack --mode=development && copyfiles -u 1 \"public/**/*\" dist",
+    "build": "webpack --mode=development",
+    "package": "copyfiles -u 1 \"public/**/*\" dist",
     "start": "docker compose up --build --force-recreate"
   },
   "devDependencies": {

--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -31,7 +31,7 @@ import { PlaygroundUtility } from './PlaygroundUtility.js';
 import { jsonRequest, jsonRequestConversion, ARRAY_ANY_ELEMENT, urlParamPrivateRepo } from './Utility.js';
 import { ActionFunction } from './ActionFunction.js';
 
-const TOKEN_HANDLER_URL = "http://127.0.0.1:10000";
+const TOKEN_HANDLER_URL = TOKEN_SERVER_URL || "http://127.0.0.1:10000";
 const COMMON_UTILITY_URL = window.location.href.replace(window.location.search,"") + "common/utility.json";
 
 var outputType = "text";

--- a/platform/webpack.config.js
+++ b/platform/webpack.config.js
@@ -1,23 +1,28 @@
 const path = require('path');
+const { DefinePlugin } = require('webpack');
 
-module.exports = {
-  mode: "development",
-  devtool: "inline-source-map",
+module.exports = (env) => {
+  return {
+    mode: "development",
+    devtool: "inline-source-map",
+    entry: './src/Playground.js',
 
-  entry: {
-	 main: './src/Playground.js',
-  },
+    resolve: {
+      alias: {
+        'xtext/xtext-ace$': path.resolve(__dirname, 'src/xtext/2.31.0/xtext-ace'),
+        'ace/range$': 'ace-builds/src-noconflict/ace',
+      }
+    },
 
-  resolve: {
-    alias: {
-      'xtext/xtext-ace$': path.resolve(__dirname, 'src/xtext/2.31.0/xtext-ace'),
-      'ace/range$': 'ace-builds/src-noconflict/ace',
-    }
-  },
-
-  output: {
-    filename: 'bundle.js',
-    path: path.resolve(__dirname, 'dist/js'),
-    clean: true,
-  },
+    output: {
+      filename: 'bundle.js',
+      path: path.resolve(__dirname, 'dist/js'),
+      clean: true,
+    },
+    plugins: [
+      new DefinePlugin({
+        'TOKEN_SERVER_URL': JSON.stringify(env.tokenServerUrl),
+      }),
+    ]
+  };
 };


### PR DESCRIPTION
I have started to look into deploying a public instance of the platform. From what I can see, it seems like the token server URL was hardcoded into the JavaScript code:

```js
const TOKEN_HANDLER_URL = "http://127.0.0.1:10000";
```

This pull request allows for customising the URL of the token handler, by using a Webpack `DefinePlugin`. The line can be changed to:

```js
const TOKEN_HANDLER_URL = TOKEN_SERVER_URL || "http://127.0.0.1:10000";
```

The TOKEN_SERVER_URL value will be replaced on the fly by Webpack using the DefinePlugin. This would allow us to tweak the URL by using the appropriate value when calling `npm`, like this:

```shell
npm run build -- --env tokenServerUrl=http://foo:1234
```

I had to separate the `copyfiles` invocation into its own `npm run package` script, as otherwise I wasn't able to pass Webpack environment variables to the build.