### PR TITLE
Composite Panel

### DIFF
--- a/platform/public/css/custom.css
+++ b/platform/public/css/custom.css
@@ -3,12 +3,8 @@
 }
 
 .editor { 
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
     height: 100%;
+    width: 100%;
 }
 
 .info { 

--- a/platform/src/ActivityManager.js
+++ b/platform/src/ActivityManager.js
@@ -82,7 +82,7 @@ class ActivityManager {
      */
     resolvePanelReference(activityId, panelRef){
 
-        const foundPanel = this.activities[activityId].panels.find( pnl => pnl.id == panelRef );
+        const foundPanel = this.findPanel(panelRef,this.activities[activityId].panels);
 
         if ( foundPanel != undefined && typeof foundPanel.id == "string" ){
             
@@ -92,6 +92,26 @@ class ActivityManager {
 
             return panelRef;
         }
+    }
+
+    /**
+     * Required to search within CompositePanels
+     * 
+     * @param {*} panelRef 
+     * @param {*} panelList 
+     * @returns 
+     */
+    findPanel(panelRef, panelList) {
+        for(let panel of panelList) {
+            if (panel.id == panelRef) return panel;
+            else {
+                if (panel.childrenPanels) {
+                    const pnl = this.findPanel(panelRef, panel.childrenPanels)
+                    if (pnl) return pnl;
+                }
+            }
+        }
+        return undefined;
     }
 
     /**
@@ -326,6 +346,30 @@ class ActivityManager {
         return null;
     }
 
+
+
+    /* resolve panel refs recursively because of CompositePanels */
+    resolveRef(panelList) {
+        for ( let apanel of panelList ){
+                
+            if (apanel.file != null) { 
+                apanel.url =  new URL( apanel.file, this.activitiesUrl).href; 
+                let file = this.fetchFile(apanel.file);
+                apanel.file = file.content;
+                apanel.sha = file.sha; 
+            };
+
+            // Resolve the panel definition reference  
+            if ( typeof apanel.ref == "string" ){
+                apanel.ref = this.accessPanelDef(apanel.ref);
+            }
+
+            if (apanel.childrenPanels) {
+                this.resolveRef(apanel.childrenPanels);
+            }
+        }
+    }
+
     /**
      * Fetches the contents of the activity with the provided ID
      */ 
@@ -335,20 +379,22 @@ class ActivityManager {
     
             var activity = this.activities[id];
 
-            for ( let apanel of activity.panels ){
-                
-                if (apanel.file != null) { 
-                    apanel.url =  new URL( apanel.file, this.activitiesUrl).href; 
-                    let file = this.fetchFile(apanel.file);
-                    apanel.file = file.content;
-                    apanel.sha = file.sha; 
-                };
+            this.resolveRef(activity.panels);
 
-                // Resolve the panel definition reference  
-                if ( typeof apanel.ref == "string" ){
-                    apanel.ref = this.accessPanelDef(apanel.ref);
-                }
-            }
+            // for ( let apanel of activity.panels ){
+                
+            //     if (apanel.file != null) { 
+            //         apanel.url =  new URL( apanel.file, this.activitiesUrl).href; 
+            //         let file = this.fetchFile(apanel.file);
+            //         apanel.file = file.content;
+            //         apanel.sha = file.sha; 
+            //     };
+
+            //     // Resolve the panel definition reference  
+            //     if ( typeof apanel.ref == "string" ){
+            //         apanel.ref = this.accessPanelDef(apanel.ref);
+            //     }
+            // }
         
             return activity;
         }

--- a/platform/src/Button.js
+++ b/platform/src/Button.js
@@ -33,12 +33,8 @@ class Button {
     
         } else if (buttonConfigObject["internal"] != undefined) {
 
-            if ((buttonConfigObject.targetPanel) && (buttonConfigObject.internal === "show" || buttonConfigObject.internal === "hide")) {
-                if (buttonConfigObject.internal === "hide") {
-                    this.action = "hidePanelById( '" + buttonConfigObject.targetPanel + "Panel' )";  
-                } else {
-                    this.action = "showPanelById( '" + buttonConfigObject.targetPanel + "Panel' )";  
-                }
+            if (buttonConfigObject.targetPanel && buttonConfigObject.internal === "toggle") {
+                this.action = "togglePanelById( '" + buttonConfigObject.targetPanel + "Panel' )";  
             } else {
                 this.action = buttonConfigObject.internal;
             }

--- a/platform/src/Button.js
+++ b/platform/src/Button.js
@@ -32,8 +32,17 @@ class Button {
             this.action = "runAction( '" + parentPanel + "', '" + buttonConfigObject.id +"' )";
     
         } else if (buttonConfigObject["internal"] != undefined) {
-            this.action = buttonConfigObject.internal;
-            
+
+            if ((buttonConfigObject.targetPanel) && (buttonConfigObject.internal === "show" || buttonConfigObject.internal === "hide")) {
+                if (buttonConfigObject.internal === "hide") {
+                    this.action = "hidePanelById( '" + buttonConfigObject.targetPanel + "Panel' )";  
+                } else {
+                    this.action = "showPanelById( '" + buttonConfigObject.targetPanel + "Panel' )";  
+                }
+            } else {
+                this.action = buttonConfigObject.internal;
+            }
+
         } else {
             console.log( "Button '" + buttonConfigObject.id + "' with uknown key.");
         }

--- a/platform/src/CompositePanel.js
+++ b/platform/src/CompositePanel.js
@@ -23,19 +23,7 @@ class CompositePanel extends Panel {
         this.childrenPanels = this.childrenPanels.filter(p => p !== panel);
     }
 
-    showPanel(panelId) {
-        const panel = this.childrenPanels.find(p => p.id === panelId);
-        if (panel) {
-            panel.setVisible(true);
-        }
-    }
 
-    hidePanel(panelId) {
-        const panel = this.childrenPanels.find(p => p.id === panelId);
-        if (panel) {
-            panel.setVisible(false);
-        }
-    }
 
     createElement() {
         var root = document.createElement("div");

--- a/platform/src/CompositePanel.js
+++ b/platform/src/CompositePanel.js
@@ -11,12 +11,14 @@ class CompositePanel extends Panel {
         super.initialize(editor)
         this.childrenPanels.forEach(panel => {
             panel.initialize(editor);
+            panel.parentComposite = this;
         });
     }
 
 
     addPanel(panel) {
         this.childrenPanels.push(panel);
+        panel.parentComposite = this; // Set a reference to the parent CompositePanel
     }
 
     removePanel(panel) {
@@ -31,14 +33,13 @@ class CompositePanel extends Panel {
         root.setAttribute("data-role", "panel");
         root.setAttribute("id", this.id + "Panel");
 
-
         root.style.display = "flex";
         root.style.flexDirection = "column";
         root.style.flex = "1";
 
         var childElementList = []
         if (this.childrenPanels) {
-            this.childrenPanels.forEach(childPanel => {
+            this.childrenPanels.forEach(childPanel => { 
                 var childElement = childPanel.getElement();
                 childElementList.push(childElement);
             });

--- a/platform/src/CompositePanel.js
+++ b/platform/src/CompositePanel.js
@@ -1,0 +1,84 @@
+import { Panel } from "./Panel.js";
+import { Layout } from "./Layout.js";
+
+class CompositePanel extends Panel {
+    childrenPanels = [];
+    constructor(id = "composite") {
+        super(id);
+    }
+
+    initialize(editor) {
+        super.initialize(editor)
+        this.childrenPanels.forEach(panel => {
+            panel.initialize(editor);
+        });
+    }
+
+
+    addPanel(panel) {
+        this.childrenPanels.push(panel);
+    }
+
+    removePanel(panel) {
+        this.childrenPanels = this.childrenPanels.filter(p => p !== panel);
+    }
+
+    showPanel(panelId) {
+        const panel = this.childrenPanels.find(p => p.id === panelId);
+        if (panel) {
+            panel.setVisible(true);
+        }
+    }
+
+    hidePanel(panelId) {
+        const panel = this.childrenPanels.find(p => p.id === panelId);
+        if (panel) {
+            panel.setVisible(false);
+        }
+    }
+
+    // You can add other composite-specific methods here, such as methods to show/hide all childrenPanels
+
+    createElement() {
+        var root = document.createElement("div");
+        root.setAttribute("class", "compositePanel");
+        root.setAttribute("data-role", "panel");
+        root.setAttribute("id", this.id + "Panel");
+
+
+        var childElementList = []
+        if (this.childrenPanels) {
+            this.childrenPanels.forEach(childPanel => {
+                var childElement = childPanel.getElement();
+                childElementList.push(childElement);
+            });
+        }
+        const splitter = Layout.createHorizontalSplitter(childElementList);
+        splitter.setAttribute("class", "h-100");
+
+        root.appendChild(splitter);
+
+        return root;
+    }
+
+    fit() {
+        this.childrenPanels.forEach(panel => {
+            if (typeof panel.fit === 'function') {
+                panel.fit();
+            }
+        });
+
+        // Fit the composite panel itself
+        const panelElement = document.getElementById(this.id + "Panel");
+        if (panelElement != null) {
+            // Assuming the parent element is the container for the composite panel
+            const parentElement = panelElement.parentElement;
+
+            // Set the width and height of the composite panel based on its parent
+            panelElement.style.width = parentElement.offsetWidth + "px";
+            panelElement.style.height = parentElement.offsetHeight + "px";
+        }
+    }
+}
+
+export { CompositePanel };

--- a/platform/src/CompositePanel.js
+++ b/platform/src/CompositePanel.js
@@ -37,14 +37,16 @@ class CompositePanel extends Panel {
         }
     }
 
-    // You can add other composite-specific methods here, such as methods to show/hide all childrenPanels
-
     createElement() {
         var root = document.createElement("div");
         root.setAttribute("class", "compositePanel");
         root.setAttribute("data-role", "panel");
         root.setAttribute("id", this.id + "Panel");
 
+
+        root.style.display = "flex";
+        root.style.flexDirection = "column";
+        root.style.flex = "1";
 
         var childElementList = []
         if (this.childrenPanels) {
@@ -62,23 +64,14 @@ class CompositePanel extends Panel {
     }
 
     fit() {
-        this.childrenPanels.forEach(panel => {
-            if (typeof panel.fit === 'function') {
-                panel.fit();
-            }
-        });
-
-        // Fit the composite panel itself
         const panelElement = document.getElementById(this.id + "Panel");
-        if (panelElement != null) {
-            // Assuming the parent element is the container for the composite panel
-            const parentElement = panelElement.parentElement;
-
-            // Set the width and height of the composite panel based on its parent
-            panelElement.style.width = parentElement.offsetWidth + "px";
-            panelElement.style.height = parentElement.offsetHeight + "px";
-        }
+        panelElement.firstChild.style.height = "100%";
+        
+        this.childrenPanels.forEach(panel => {
+            panel.fit();
+        });
     }
+    
 }
 
 export { CompositePanel };

--- a/platform/src/ConsolePanel.js
+++ b/platform/src/ConsolePanel.js
@@ -55,8 +55,8 @@ class ConsolePanel extends Panel {
         root.setAttribute("id", this.id + "Panel");
 
         var editor = document.createElement("div");
-        editor.setAttribute("id", this.id + "Editor");
         editor.setAttribute("class", "editor");
+        editor.setAttribute("id", this.id + "Editor");
 
         root.appendChild(editor);
 

--- a/platform/src/ConsolePanel.js
+++ b/platform/src/ConsolePanel.js
@@ -6,9 +6,13 @@ class ConsolePanel extends Panel {
 
     constructor(id) {
         super(id);
+    }
+
+    intialize(editor) {
+        super.initialize(editor)
+
         this.editor.setReadOnly(true);
         this.editor.setValue("", 1);
-
         let buttons = [];
         let clearButton = new Button(
             { id:"clear", 

--- a/platform/src/ModelPanel.js
+++ b/platform/src/ModelPanel.js
@@ -130,17 +130,30 @@ class ModelPanel extends Panel {
 
     fit() {
         // Fit the editor
+        // var editorElement = document.getElementById(this.id + "Editor");
+        // if (editorElement != null) {
+        //     editorElement.parentNode.parentNode.style = "flex-basis: calc(100% - 4px); padding: 0px";
+        //     var parentElement = editorElement.parentElement.parentElement.parentElement;
+        //     editorElement.style.width = parentElement.offsetWidth + "px";
+        //     editorElement.style.height = parentElement.offsetHeight - 42 + "px";
+        // }
+        // this.editor.resize();
+
+
+
         var editorElement = document.getElementById(this.id + "Editor");
-        if (editorElement != null) {
-            editorElement.parentNode.parentNode.style = "flex-basis: calc(100% - 4px); padding: 0px";
-            var parentElement = editorElement.parentElement.parentElement.parentElement;
-            editorElement.style.width = parentElement.offsetWidth + "px";
-            editorElement.style.height = parentElement.offsetHeight - 42 + "px";
+        var parentElement = editorElement.parentElement
+        var g1 = parentElement.parentElement
+        var g2 = g1.parentElement
+        var g3 = g2.parentElement
+        var g4 = g3.parentElement
+        var g5 = g4.parentElement
 
-        }
-
+        g1.style = "flex-basis: calc(100% - 4px); padding: 0px";
+        editorElement.style.width = g4.offsetWidth + "px";
+        editorElement.style.height = g4.offsetHeight - 42 + "px";
         this.editor.resize();
-        
+
         // Fit the diagram
         var diagramElement = document.getElementById(this.id + "Diagram");
         if (diagramElement != null) {

--- a/platform/src/ModelPanel.js
+++ b/platform/src/ModelPanel.js
@@ -12,6 +12,11 @@ class ModelPanel extends Panel {
         super(id);
         this.editable = editable;
         this.metamodelPanel = metamodelPanel;
+    }
+
+    initialize(editor) {
+        super.initialize(editor);
+
         this.setupSyntaxHighlighting();
         this.setTitleAndIcon("Model", "flexmi");
     }
@@ -131,6 +136,7 @@ class ModelPanel extends Panel {
             var parentElement = editorElement.parentElement.parentElement.parentElement;
             editorElement.style.width = parentElement.offsetWidth + "px";
             editorElement.style.height = parentElement.offsetHeight - 42 + "px";
+
         }
 
         this.editor.resize();

--- a/platform/src/OutputPanel.js
+++ b/platform/src/OutputPanel.js
@@ -16,6 +16,11 @@ class OutputPanel extends ModelPanel {
         this.outputLanguage = outputLanguage;
         this.language = language;
 
+    }
+
+    initialize(editor) {
+        super.initialize(editor);
+
         let buttons = []; 
         if (this.outputType == "code"){
             let highlightButton = new Button(
@@ -29,7 +34,7 @@ class OutputPanel extends ModelPanel {
         }
         this.addButtons(buttons);
 
-        this.getEditor().getSession().setMode("ace/mode/" + outputLanguage.toLowerCase());
+        this.getEditor().getSession().setMode("ace/mode/" + this.outputLanguage.toLowerCase());
     }
 
     setupSyntaxHighlighting() {}

--- a/platform/src/OutputPanel.js
+++ b/platform/src/OutputPanel.js
@@ -130,27 +130,6 @@ class OutputPanel extends ProgramPanel {
 
 
 
-    // renderDiagram(svg) {
-    //     var diagramId = this.id + "Panel";
-    //     var diagramElement = document.getElementById(diagramId);
-    //     diagramElement.innerHTML = svg;
-    //     var svg = document.getElementById(diagramId).firstElementChild;
-        
-    //     //if (diagramId == "outputDiagram") {
-    //         diagramElement.parentElement.style.padding = "0px";
-    //     //}
-    
-    //     // svg.style.width = diagramElement.offsetWidth + "px";
-    //     // svg.style.height = diagramElement.offsetHeight + "px";
-
-
-    //     svgPanZoom(svg, {
-    //       zoomEnabled: true,
-    //       fit: true,
-    //       center: true
-    //     });
-    // }
-
     renderDiagram(svg) {
         var diagramId = this.id + "Panel";
         var diagramElement = document.getElementById(diagramId);
@@ -173,7 +152,7 @@ class OutputPanel extends ProgramPanel {
             center: true
         });
     }
-
+    
     
 
 }

--- a/platform/src/OutputPanel.js
+++ b/platform/src/OutputPanel.js
@@ -1,9 +1,9 @@
 
-import { ModelPanel } from "./ModelPanel.js";
+import { ProgramPanel } from "./ProgramPanel.js";
 import { language } from "./Playground.js";
 import { Button } from "./Button.js";
-
-class OutputPanel extends ModelPanel {
+import svgPanZoom from 'svg-pan-zoom';
+class OutputPanel extends ProgramPanel {
 
     outputType;
     outputLanguage;
@@ -127,6 +127,54 @@ class OutputPanel extends ModelPanel {
         root.insertBefore(select, root.children[0]);
         console.log(this.select);
     }
+
+
+
+    // renderDiagram(svg) {
+    //     var diagramId = this.id + "Panel";
+    //     var diagramElement = document.getElementById(diagramId);
+    //     diagramElement.innerHTML = svg;
+    //     var svg = document.getElementById(diagramId).firstElementChild;
+        
+    //     //if (diagramId == "outputDiagram") {
+    //         diagramElement.parentElement.style.padding = "0px";
+    //     //}
+    
+    //     // svg.style.width = diagramElement.offsetWidth + "px";
+    //     // svg.style.height = diagramElement.offsetHeight + "px";
+
+
+    //     svgPanZoom(svg, {
+    //       zoomEnabled: true,
+    //       fit: true,
+    //       center: true
+    //     });
+    // }
+
+    renderDiagram(svg) {
+        var diagramId = this.id + "Panel";
+        var diagramElement = document.getElementById(diagramId);
+        diagramElement.innerHTML = svg;
+    
+        // Ensure that the container has no padding or margin
+        diagramElement.style.padding = "0";
+        diagramElement.style.margin = "0";
+    
+        var svgElement = diagramElement.firstElementChild;
+    
+        // Set the SVG's width and height to 100% of the container
+        svgElement.style.width = "100%";
+        svgElement.style.height = "100%";
+    
+        // Initialize SVG pan and zoom
+        svgPanZoom(svgElement, {
+            zoomEnabled: true,
+            fit: true,
+            center: true
+        });
+    }
+
+    
 
 }
 

--- a/platform/src/Panel.js
+++ b/platform/src/Panel.js
@@ -27,10 +27,10 @@ class Panel {
                 fontSize: "11pt",
                 useSoftTabs: true
             });
+
         } else {
             this.editor = editor;
         }
-        
         this.visible = true;
     }
 

--- a/platform/src/Panel.js
+++ b/platform/src/Panel.js
@@ -8,8 +8,12 @@ class Panel {
     valueSha;
     fileUrl;
 
-    constructor(id, editor) {
+    constructor(id) {
         this.id = id;
+        
+    }
+
+    initialize(editor) {
         this.getElement();
 
         // Set up the panel's editor
@@ -26,7 +30,7 @@ class Panel {
         } else {
             this.editor = editor;
         }
-        
+
         this.visible = true;
     }
 

--- a/platform/src/Panel.js
+++ b/platform/src/Panel.js
@@ -30,7 +30,7 @@ class Panel {
         } else {
             this.editor = editor;
         }
-
+        
         this.visible = true;
     }
 

--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -306,7 +306,7 @@ function initialisePanels() {
                 // Set from the activity 
                 newPanel.setValue(panel.file);
                 newPanel.setValueSha(panel.sha); 
-                newPanel.setFileUrl(panel.url)
+                newPanel.setFileUrl(panel.url);
             break;
         
             case "ConsolePanel":
@@ -318,8 +318,8 @@ function initialisePanels() {
                 newPanel =  new OutputPanel(newPanelId, panelDefinition.language, outputType, outputLanguage);
                 newPanel.initialize();
 
-                newPanel.hideEditor();
-                newPanel.showDiagram();
+                // newPanel.hideEditor();
+                // newPanel.showDiagram();
             break;
 
             case "XtextEditorPanel":
@@ -759,12 +759,12 @@ function handleResponseActionFunction(action, requestPromise){
 
             } else if (responseDiagram != undefined) {
                 // Diagrams 
-                outputPanel.hideEditor(); // TODO Showing diagram before and after renderDiagrams makes outputs image show in panel otherwise nothing. 
-                outputPanel.showDiagram();
+                // outputPanel.hideEditor(); // TODO Showing diagram before and after renderDiagrams makes outputs image show in panel otherwise nothing. 
+                // outputPanel.showDiagram();
                 
                 outputPanel.renderDiagram( response[responseDiagram] );
                 
-                outputPanel.showDiagram();
+                // outputPanel.showDiagram();
                 
             } else if (response.generatedFiles) {
                 // Multiple text files
@@ -808,12 +808,12 @@ function handleResponseActionFunction(action, requestPromise){
                         krokiXhr.onreadystatechange = function () {
                             if (krokiXhr.readyState === 4) {
                                 if (krokiXhr.status === 200) {
-                                    outputPanel.hideEditor(); // TODO Showing diagram before and after renderDiagrams makes outputs image show in panel otherwise nothing. 
-                                    outputPanel.showDiagram();
+                                    // outputPanel.hideEditor(); // TODO Showing diagram before and after renderDiagrams makes outputs image show in panel otherwise nothing. 
+                                    // outputPanel.showDiagram();
 
                                     outputPanel.renderDiagram(krokiXhr.responseText);
 
-                                    outputPanel.showDiagram();
+                                    // outputPanel.showDiagram();
                                 }
                             }
                         };

--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -372,7 +372,7 @@ function initialisePanels() {
             // No activity defined buttons
             newPanel.addButtons( Button.createButtons( panelDefinition.buttons, panel.id));
 
-        } else if (panel.buttons != null && panelDefinition.buttons != null) {
+        } else if (panel.buttons != null && panelDefinition.buttons == null) {
             // The activity has defined the buttons
             let resolvedButtonConfigs = panel.buttons.map(btn =>{    
                 let resolvedButton;
@@ -903,6 +903,23 @@ function runAction(source, sourceButton) {
     longNotification("Executing program");
 }
 
+
+
+function hidePanelById(elementId) {
+    const panelElement = document.getElementById(elementId);
+    if (panelElement) {
+        $("#" + panelElement.parentElement.id).hide();
+     }
+}
+
+function showPanelById(elementId) {
+    const panelElement = document.getElementById(elementId);
+    if (panelElement) {
+        $("#" + panelElement.parentElement.id).show();
+    }
+}
+
+
 function notification(title, message, cls="light"){
     const crossIcon = "<div class=\"default-icon-cross\" style=\"float:right\"></div>"
     Metro.notify.create(crossIcon + "<b>"  + title + "</b>" + "<br>" + message + "<br>", null, {keepOpen: true, cls: cls, width: 300});
@@ -1053,6 +1070,8 @@ async function checkEditorReady(statusUrl, editorInstanceUrl, editorPanelId, edi
     window.fit = fit;
     window.updateGutterVisibility = updateGutterVisibility;
     window.runAction = runAction;
+    window.hidePanelById = hidePanelById;
+    window.showPanelById = showPanelById;
     window.panels = panels;
     window.savePanelContents = savePanelContents;
     window.backend = backend;

--- a/platform/src/ProgramPanel.js
+++ b/platform/src/ProgramPanel.js
@@ -22,7 +22,7 @@ class ProgramPanel extends Panel {
     fit() {
         var editorElement = document.getElementById(this.id + "Editor");
         if (editorElement != null) {
-            editorElement.parentNode.style = "flex-basis: calc(100% - 4px);";
+            editorElement.parentElement.style = "flex-basis: calc(100% - 4px);";
         }
         this.editor.resize();
     }

--- a/platform/src/ProgramPanel.js
+++ b/platform/src/ProgramPanel.js
@@ -35,8 +35,8 @@ class ProgramPanel extends Panel {
         root.setAttribute("id", this.id + "Panel");
 
         var editor = document.createElement("div");
-        editor.setAttribute("id", this.id + "Editor");
         editor.setAttribute("class", "editor");
+        editor.setAttribute("id", this.id + "Editor");
 
         root.appendChild(editor);
         


### PR DESCRIPTION
# CompositePanel

The CompositePanel serves as a structural design pattern in the playground UI, employing the concept of composition to enhance modularity. It extends the `Panel` class and acts as a composite object that can encapsulate multiple sub-panels.
This allows for the creation of a hierarchical structure of panels, akin to a tree structure in object-oriented design. There are no inherent restrictions on the number of contained panels, and this includes the possibility of nesting other CompositePanels.

A typical use case is to use a composite panel to couple an editor with a diagram. See an example in [YAMTL's playground](https://yamtl.github.io/playground/?activities=https://yamtl.github.io/playground-activities/yamtl-cd2db.yml), where CompositePanels have been used to implemente MetamodelPanel and ModelPanel.

### Configuration

A composite panel def needs to be declared in the tool configuration:

```yaml
  panelDefs:
    - id: composite-panel
      panelclass: CompositePanel
      icon: diagram
```

A composite panel is wired in an activity and declares `childrenPanels`, giving some structure to the UI of the playground.

```yaml
  panels:
    - id: smm-panel-composite
      name: Source Metamodel
      ref: composite-panel
      childrenPanels:
        - id: panel-smm
          name: EMFatic
          ref: emfatic
          file: CD.emf
        - id: panel-smm-diagram
          name: Diagram
         ref: plantuml
      buttons:
        - id: show-editor-button
          icon:  editor
          internal: toggle
          targetPanel: panel-smm
          hint: Toggle editor
        - id: show-diagram-button
          icon:  diagram
          internal: toggle
          targetPanel: panel-smm-diagram
          hint: Toggle diagram
```

`CompositePanel` can be regarded as the composition operator of a DSL for defining UIs for the playground.

Internal toggle buttons are now built-in and can be used to toggle contained panels. A toggle button is declared within the section `buttons` of a composite panel and is defined with `id`, `name`, `icon` and `hint`. In addition, the `internal` action must be `toggle` and the `targetPanel` must be the panel to be toggled. 

### Changes that were implemented

* Element creation is now made outside of constructors because we could not use constructor parameters in `createElement`. Hence, a new operator `initialize` has been added to `Panel` and this needs to be overriden by `Panel` specializations. Once a panel is instantiated, it needs to be explicitly initialized.
* `OutputPanel` now extends `ProgramPanel`. `ModelPanel` can be regarded as an instance of `CompositePanel` and is therefore not needed explicitly.
* Finding panels now requires traversing the structure created by CompositePanels.

### Future work

* Add validation to cover toggle buttons.
