### PR TITLE
Only show 'Save' button when authenticated

### DIFF
--- a/platform/public/css/custom.css
+++ b/platform/public/css/custom.css
@@ -165,7 +165,7 @@ body {
 }
 
 .hidden {
-	display:none;
+	display: none !important;
 }
 
 .ace_gutter {

--- a/platform/public/index.html
+++ b/platform/public/index.html
@@ -35,7 +35,7 @@
                 <li class="item-separator"></li>
                 <li class="item-separator" id="examplesEnd"></li>
                 <li>
-                    <a href="#" onclick="savePanelContents(event)" id="save">
+                    <a href="#" onclick="savePanelContents(event)" id="save" class="hidden">
                         <span class="icon"><span class="mif-example-16 mif-save"></span></span>
                         <span class="caption">Save</span>
                     </a>

--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -92,13 +92,11 @@ if (urlParameters.has("code") && urlParameters.has("state")  ){
     tokenRequest.code = urlParameters.get("code");
 
     //TODO loading box
-    let authDetails=  jsonRequest(TOKEN_HANDLER_URL + "/mdenet-auth/login/token",
-                                               JSON.stringify(tokenRequest), true );
-    authDetails.then( (details) => {
-        console.log("AUTHENTICATED: " + details.toString());
-        
+    let authDetails = jsonRequest(TOKEN_HANDLER_URL + "/mdenet-auth/login/token",
+                                  JSON.stringify(tokenRequest), true );
+    authDetails.then((details) => {
+        document.getElementById('save')?.classList.remove('hidden');
         window.sessionStorage.setItem("isAuthenticated", true);
-
         initialiseActivity();
     } );
 }


### PR DESCRIPTION
Fixes #130 

This pull request adds the CSS class `hidden` (whose display value is now `!important`) to the Save button, and tweaks the code that handles the event when we authenticate to GitHub to remove that class, so the Save button is shown.