### PR TITLE
Allow trusted origins to be configured via .env

### DIFF
--- a/tokenserver/src/config.js
+++ b/tokenserver/src/config.js
@@ -12,7 +12,7 @@ export const config = {
 
     encKey: process.env.TS_ENC_KEY,
 
-    trustedWebOrigins: ['http://127.0.0.1:8080'],
+    trustedWebOrigins: process.env.TRUSTED_ORIGINS?.split(",") || 'http://127.0.0.1:8080',
 
     cookieOptions: {
         httpOnly: true,


### PR DESCRIPTION
This should help with the customisability of the token server, by adding support for specifying the trusted origins by setting `TRUSTED_ORIGINS` to a comma-separated list of origins in the `.env` file.