### PR TITLE
Add 'activitiesFromReferrer' query string key

### DIFF
--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -52,7 +52,38 @@ export var toolsManager;
 
 var urlParameters = new URLSearchParams(window.location.search);    
 
+// Redirect to activities file contained in referrer.
+//
+// This can be useful for providing a link to the MDENet EP from the README,
+// in a way that translates automatically to forks. It only works if the
+// referrer is something like https://github.com/user/repo, and would be used
+// like this (where '/main' means to fetch it from the main branch, and
+// '/activity.json' is the path in that branch):
+//
+// https://host/?activitiesFromReferrer=/main/activity.json&privaterepo=true
 
+const PARAM_ACTFROMREF = 'activitiesFromReferrer';
+const RAW_URL_PREFIX = 'https://raw.githubusercontent.com/';
+if (document.referrer && urlParameters.has(PARAM_ACTFROMREF)) {
+  let referrerAddress = new URL(document.referrer);
+  let pathSegments = referrerAddress.pathname.split('/');
+  if (referrerAddress.host == 'github.com' && pathSegments.length >= 3) {
+    let ghUser = pathSegments[1];
+    let ghRepo = pathSegments[2];
+
+    var activity = urlParameters.get(PARAM_ACTFROMREF);
+    if (!activity.startsWith('/')) {
+      activity = '/' + activity;
+    }
+
+    // Redirect to the URL with the full ?activities key
+    let activitiesUrl = RAW_URL_PREFIX + ghUser + '/' + ghRepo + activity;
+    let docAddress = new URL(document.location.href);
+    docAddress.searchParams.delete(PARAM_ACTFROMREF);
+    docAddress.searchParams.append('activities', activitiesUrl);
+    window.location.replace(docAddress.toString());
+  }
+}
 
 document.getElementById("btnnologin").onclick= () => {
     PlaygroundUtility.hideLogin();


### PR DESCRIPTION
I have tried using Github Classroom to set up an assignment based on a template repository, with the MDENet EP app installed into the classroom's organisation, and this has worked fine.

However, it requires students to manually tweak the `activities` query parameter, which I think is a bit unwieldy. In this PR, I add an alternative which uses the `Referrer` header sent by the browser when clicking on a link from the repository's `README` file. You would be able to add a link like this to your README:

```
protocol://host/?activitiesFromReferrer=/main/activity.json&privaterepo=true
```

This link would redirect to the `activity.json` file from the `main` branch of the repository whose README link we just clicked on, meaning we could set up a template repository and it would always work, so long as the private repo has the appropriate Github app installed.

This PR is pending to be tested in our current deployment - Cloudflare is taking a while to revalidate their cache.
