### PR TITLE
Add support for URL interpolation when setting up panels

### DIFF
--- a/platform/src/ActivityManager.js
+++ b/platform/src/ActivityManager.js
@@ -354,12 +354,8 @@ class ActivityManager {
     interpolate(someString) {
         let result = someString;
 
-        // console.log (`Asked to interpolate ${someString}.`);
-
         for (let i = 0; i < sessionStorage.length; i++) {
             let currentKey = sessionStorage.key(i);
-
-            // console.log(`Interpolating for key ${currentKey}.`);
 
             if (currentKey !== "isAuthenticated") {
                 // TODO: This *assumes* this can only be a panel ID, but that may change over time,
@@ -368,7 +364,6 @@ class ActivityManager {
             }
         }
 
-        // console.log(`Result of interpolation: ${result}.`);
         return result;
     }
 

--- a/platform/src/ActivityManager.js
+++ b/platform/src/ActivityManager.js
@@ -360,7 +360,7 @@ class ActivityManager {
             if (currentKey !== "isAuthenticated") {
                 // TODO: This *assumes* this can only be a panel ID, but that may change over time,
                 // so this code may need to be improved to only allow access to panel IDs explicitly
-                result = result.replace("${ID-" + currentKey + "}", sessionStorage.getItem(currentKey));
+                result = result.replace("{{ID-" + currentKey + "}}", sessionStorage.getItem(currentKey));
             }
         }
 

--- a/platform/src/ActivityManager.js
+++ b/platform/src/ActivityManager.js
@@ -346,15 +346,40 @@ class ActivityManager {
         return null;
     }
 
+    /**
+     * Interpolate someString using information from session storage.
+     * 
+     * @param {*} someString the string to be changed
+     */
+    interpolate(someString) {
+        let result = someString;
 
+        // console.log (`Asked to interpolate ${someString}.`);
+
+        for (let i = 0; i < sessionStorage.length; i++) {
+            let currentKey = sessionStorage.key(i);
+
+            // console.log(`Interpolating for key ${currentKey}.`);
+
+            if (currentKey !== "isAuthenticated") {
+                // TODO: This *assumes* this can only be a panel ID, but that may change over time,
+                // so this code may need to be improved to only allow access to panel IDs explicitly
+                result = result.replace("${ID-" + currentKey + "}", sessionStorage.getItem(currentKey));
+            }
+        }
+
+        // console.log(`Result of interpolation: ${result}.`);
+        return result;
+    }
 
     /* resolve panel refs recursively because of CompositePanels */
     resolveRef(panelList) {
         for ( let apanel of panelList ){
                 
-            if (apanel.file != null) { 
-                apanel.url =  new URL( apanel.file, this.activitiesUrl).href; 
-                let file = this.fetchFile(apanel.file);
+            if (apanel.file != null) {
+                let panelURLString = this.interpolate(apanel.file);
+                apanel.url =  new URL(panelURLString, this.activitiesUrl).href; 
+                let file = this.fetchFile(panelURLString);
                 apanel.file = file.content;
                 apanel.sha = file.sha; 
             };

--- a/platform/src/FileHandler.js
+++ b/platform/src/FileHandler.js
@@ -12,38 +12,39 @@ class FileHandler {
 
     fetchFile(url, isPrivate){
 
-        if(isPrivate){
-
+        if (isPrivate){
             // Private so request via token server
             const requestUrl = this.getPrivateFileRequestUrl(url);
 
-            var xhr = new XMLHttpRequest();
-            xhr.open("GET", requestUrl, false);
-            xhr.withCredentials = true;
-            xhr.send();
-            
-            if (xhr.status === 200) {  
+            if (requestUrl != null) {
+                var xhr = new XMLHttpRequest();
+                xhr.open("GET", requestUrl, false);
+                xhr.withCredentials = true;
+                xhr.send();
                 
-                let response = JSON.parse(xhr.responseText);
-
-                return { content: window.atob(response.data.content), sha: response.data.sha };
-            
-            } else {
-                return null;
-            }           
+                if (xhr.status === 200) {  
+                    
+                    let response = JSON.parse(xhr.responseText);
+    
+                    return { content: window.atob(response.data.content), sha: response.data.sha };
+                
+                } else {
+                    return null;
+                }
+            }
+        }
+        
+        // At this point, this is either a public repository, or it's a private repository but an unknown type of URL.
+        // In either case, we assume that we can simply access the URL directly.
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", url, false);
+        xhr.send();
+        
+        if (xhr.status === 200) {    
+            return { content: xhr.responseText, sha: null }; //TODO need to retrieve the sha for the file IF it's from a public repository
 
         } else {
-            // Public so request directly
-            var xhr = new XMLHttpRequest();
-            xhr.open("GET", url, false);
-            xhr.send();
-            
-            if (xhr.status === 200) {    
-                return { content: xhr.responseText, sha: null }; //TODO need to retrieve the sha for the file
-
-            } else {
-                return null;
-            }
+            return null;
         }
     }
 

--- a/platform/src/ProgramPanel.js
+++ b/platform/src/ProgramPanel.js
@@ -9,7 +9,7 @@ class ProgramPanel extends Panel {
 
     canSave() {
         // Only save if there are any actual changes to save -- this avoids empty commits.
-        return !(this.editor.session.getUndoManager().isClean());
+        return (this.getValueSha()) && (!(this.editor.session.getUndoManager().isClean()));
     }
 
     /**

--- a/platform/src/XtextEditorPanel.js
+++ b/platform/src/XtextEditorPanel.js
@@ -33,7 +33,7 @@ class XtextEditorPanel extends Panel {
 
     canSave() {
         // Only save if there are any actual changes to save -- this avoids empty commits.
-        return !(this.editor.session.getUndoManager().isClean());
+        return (this.getValueSha()) && (!(this.editor.session.getUndoManager().isClean()));
     }
 
     /**


### PR DESCRIPTION
This PR adds support for interpolation in panel URLs in the activity specification.

This is useful to allow dependent activities to access information from other activities. The concrete motivating example was the generation of Xtext editors, where I may wish to allow students to access the meta-model generated by Xtext in the activity where they can try out their new language. The URL to that file is generated by the platform (specifically, the xtext tool) and so isn't known at the time when the activity specification file is written.

With this PR, I can now write something like:

```
{
  "id": "panel-mm",
  "name": "The meta-model generated by Xtext",
  "ref": "ecore",
  "file": "{{ID-panel-turtles}}/xtext-resources/generated/meta-model.ecore"
},
```
and have `{{ID-panel-turtles}}` replaced from session storage associated with the `panel-turtles` panel at runtime. For generated editors, the platform stores the editor URL in that session storage key.

This is a somewhat pragmatic change, which could be made more powerful, but for now I suggest we keep things simple. We may need to invest in a more systematic architecture should there be a need for more flexibility at any point down the line.

The change consists of two separate changes:

1. Changing `ActivityManager.js` to perform the URL interpolation, and
2. Changing `FileHandler.js` to gracefully manage unknown types of URLs even for private repositories.

The latter change isn't strictly related to URL interpolation, but is required so that the generated URL can actually be used by the platform even when the activity lives in a private repository. To make this compatible with how file saving is managed, I have also adjusted the code for `canSave` in various panel types to ensure we only attempt to save a panel when it actually has an associated SHA and, thus, we know that it came from the original repository. This may make it difficult for the platform to save back to _public_ repositories.