### PR TITLE
For metamodel-free conversion, ensure we're converting the correct value

### DIFF
--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -442,7 +442,7 @@ function invokeActionFunction(functionId, parameterMap){
             
             if(metamodelId==null){
                 // Convert with no metamodel to consider
-                convertedValue = convert( givenParameter.val, givenParameter.type, 
+                convertedValue = convert( givenParameter.value, givenParameter.type, 
                                           actionFunctionParam.type, paramName ); // TODO issue #58 remove paramName
 
             } else {


### PR DESCRIPTION
A typo in the conversion code meant we weren't passing the actual panel contents to the conversion function.