### PR TITLE
Add support for URL rewriting in tool specifications

### DIFF
--- a/platform/src/ActivityManager.js
+++ b/platform/src/ActivityManager.js
@@ -360,7 +360,8 @@ class ActivityManager {
             if (currentKey !== "isAuthenticated") {
                 // TODO: This *assumes* this can only be a panel ID, but that may change over time,
                 // so this code may need to be improved to only allow access to panel IDs explicitly
-                result = result.replace("{{ID-" + currentKey + "}}", sessionStorage.getItem(currentKey));
+                // Removing trailing slash to avoid double slashes
+                result = result.replace("{{ID-" + currentKey + "}}", sessionStorage.getItem(currentKey).replace(/\/$/, ""));
             }
         }
 

--- a/platform/src/ToolsManager.js
+++ b/platform/src/ToolsManager.js
@@ -65,8 +65,12 @@ class ToolManager {
             }
 
             if (xhr.status === 200) {    
+                // Rewrite URLs in tool config
+                let baseURL = toolUrl.url.substring(0, toolUrl.url.lastIndexOf("/")); // remove the name of the json file (including the trailing slash)
+                let toolConfig = xhr.responseText.replaceAll("{{BASE-URL}}", baseURL);
 
-                let validatedConfig = this.parseAndValidateToolConfig(xhr.responseText);
+                // Now parse tool config
+                let validatedConfig = this.parseAndValidateToolConfig(toolConfig);
 
                 if ( validatedConfig.errors.length == 0 ){
                     


### PR DESCRIPTION
This PR adds support for tool specifications to use `{{BASE-URL}}` to refer to the URL from which the tool is deployed (strictly, the URL where the tool specification is hosted, minus the file name of the tool specification and any trailing `/`). This will automatically be rewritten when the tool specification is loaded, so that tool specifications can be written independently of location of deployment.