### PR TITLE
Fix hiding of generated activities

### DIFF
--- a/platform/src/ActivityManager.js
+++ b/platform/src/ActivityManager.js
@@ -509,9 +509,10 @@ class ActivityManager {
         let generatedPanelFound = false;
 
         for (const panel of  this.activities[activityId].panels) {
-            
-            if (this.accessPanelDef(panel.ref)?.generated  && !this.isPanelGenerated(panel.id) ){
-                generatedPanelFound = this.accessPanelDef(panel.ref).generated;
+            let panelDef = this.accessPanelDef(panel.ref);
+            // If no panel definition can be found, treat the panel as generated. Panel definitions may only be contributed by generated tools.
+            if ((!panelDef) || (panelDef.generated  && !this.isPanelGenerated(panel.id))) {
+                generatedPanelFound = true;
                 break;
             }
         }


### PR DESCRIPTION
This PR fixes a bug introduced by #161. Because tools with URL-rewriting in the tool URL may not be loaded unless they have been generated, any panels provided by them can also not be loaded unless the tool has been generated. As a result, checking if a panel is a generated panel cannot rely on the panel definition in these cases. Before this fix, activities with such panels would be shown in the activities menu regardless of whether generation has taken place.

To fix this, we assume that all panels with undefined panel definitions are generated and hide the corresponding activities in the menu. This also has the nice side effect that only activities with fully defined panels are visible in the menu.