### PR TITLE
Do not assume action parameters are strings

### DIFF
--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -872,7 +872,6 @@ function runAction(source, sourceButton) {
         } else {
             // No panel with ID so it use as the parameter value
             const parameterValue = action.parameters[paramName];
-            // console.log(`The panel ID starting with ${parameterValue.substring(0,10)}... not found. Using it as a the parameter value for ${paramName}.`);
             param.type = 'text';
             param.value = parameterValue;
         }

--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -872,7 +872,7 @@ function runAction(source, sourceButton) {
         } else {
             // No panel with ID so it use as the parameter value
             const parameterValue = action.parameters[paramName];
-            console.log(`The panel ID starting with ${parameterValue.substring(0,10)}... not found. Using it as a the parameter value for ${paramName}.`);
+            // console.log(`The panel ID starting with ${parameterValue.substring(0,10)}... not found. Using it as a the parameter value for ${paramName}.`);
             param.type = 'text';
             param.value = parameterValue;
         }


### PR DESCRIPTION
This PR fixes a bug where the platform crashed when an action parameter wasn't actually a string