### PR TITLE
Fix UTF-8 decoding errors

### DIFF
--- a/platform/src/FileHandler.js
+++ b/platform/src/FileHandler.js
@@ -10,6 +10,11 @@ class FileHandler {
     }
 
 
+    base64ToBytes(base64) {
+        const binString = window.atob(base64);
+        return Uint8Array.from(binString, (m) => m.codePointAt(0));
+    }
+
     fetchFile(url, isPrivate){
 
         if (isPrivate){
@@ -19,14 +24,17 @@ class FileHandler {
             if (requestUrl != null) {
                 var xhr = new XMLHttpRequest();
                 xhr.open("GET", requestUrl, false);
+                xhr.setRequestHeader("Accept", "application/json; charset=UTF-8");
                 xhr.withCredentials = true;
                 xhr.send();
                 
                 if (xhr.status === 200) {  
                     
                     let response = JSON.parse(xhr.responseText);
-    
-                    return { content: window.atob(response.data.content), sha: response.data.sha };
+
+                    let contents = new TextDecoder().decode(this.base64ToBytes(response.data.content));
+
+                    return { content: contents, sha: response.data.sha };
                 
                 } else {
                     return null;

--- a/platform/src/Utility.js
+++ b/platform/src/Utility.js
@@ -45,7 +45,7 @@ export function jsonRequest(url, json, useCredentials=false){
         var xhr = new XMLHttpRequest();
 
         xhr.open("POST", url);
-        xhr.setRequestHeader("Content-Type", "application/json");
+        xhr.setRequestHeader("Content-Type", "application/json; charset=UTF-8");
         xhr.withCredentials = useCredentials;
         
         xhr.onload = function () {


### PR DESCRIPTION
This PR fixes some issues with encoding / decoding of UTF-8, especially in relation to Base64 (see also https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem for explanation of the problem). This is important, for example, because Xtend code uses guillemets which are only available in UTF-8, not plain ASCII.