### PR TITLE
Fix for missing panel buttons

### DIFF
--- a/platform/schemas/panel.schema.json
+++ b/platform/schemas/panel.schema.json
@@ -29,6 +29,17 @@
         "editorPanel": {
             "description": "For tools that create editor instances e.g. language workbenches, reference to the id of a panel of editorActivity that is the editor instance.",
             "type": "string"
+        },
+        "buttons": {
+            "description": "Buttons to use instead of the default buttons defined by the panel. Can be a Button object or an Object with a ref attribute whose value is the id of a button from the panel's definition.",
+            "type": "array",
+            "items": {
+                "type": "object", 
+                "oneOf": [
+                    {"$ref": "button.schema.json"},
+                    {"$ref": "ref.schema.json"}
+                 ]
+            }
         }
     },
     "required": ["id", "name", "ref"]

--- a/platform/schemas/ref.schema.json
+++ b/platform/schemas/ref.schema.json
@@ -1,0 +1,15 @@
+{
+    "$id": "https://mde-network.com/ep/ref.schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "EP Ref1",
+    "description": "The MDENet education platform reference",
+
+    "type": "object",
+    "properties": {
+        "ref": {
+            "description": "The id of an education platform element.",
+            "type": "string"
+        }
+    },
+    "required": ["ref"]
+}

--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -384,9 +384,9 @@ function createPanelForDefinitionId(panel){
             let resolvedButtonConfigs = panel.buttons.map(btn =>{    
                 let resolvedButton;
 
-                if (typeof btn == "string"){
+                if (btn.ref){
                     // button reference so resolve
-                    resolvedButton= panelDefinition.buttons.find((pdBtn)=> pdBtn.id===btn);
+                    resolvedButton= panelDefinition.buttons.find((pdBtn)=> pdBtn.id===btn.ref);
                 } else {
                     // activity defined button
                     resolvedButton= btn;

--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -379,14 +379,14 @@ function createPanelForDefinitionId(panel){
             // No activity defined buttons
             newPanel.addButtons( Button.createButtons( panelDefinition.buttons, panel.id));
 
-        } else if (panel.buttons != null && panelDefinition.buttons == null) {
+        } else if (panel.buttons != null && panelDefinition.buttons != null) {
             // The activity has defined the buttons
             let resolvedButtonConfigs = panel.buttons.map(btn =>{    
                 let resolvedButton;
 
-                if (btn.ref){
+                if (typeof btn == "string"){
                     // button reference so resolve
-                    resolvedButton= panelDefinition.buttons.find((pdBtn)=> pdBtn.id===btn.ref);
+                    resolvedButton= panelDefinition.buttons.find((pdBtn)=> pdBtn.id===btn);
                 } else {
                     // activity defined button
                     resolvedButton= btn;


### PR DESCRIPTION
Fix for missing panel buttons. Panel definitions are required to resolve any button references given in an activity config file. Button references are identified by their type that is string rather than object for Buttons.