### PR TITLE
Report all errors on playground start up

### DIFF
--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -245,6 +245,21 @@ function displayErrors(errors){
                 contentPanelDiv.append(content);
             });
         }
+
+        const otherErrors = errors.filter((e) => !(configErrors.includes(e) || platformErrors.includes(e)))
+        if (otherErrors.length > 0) {
+            let contentTitle = document.createElement("h2");
+            contentTitle.innerText = "Errors:";
+            contentPanelDiv.append(contentTitle);
+
+            otherErrors.forEach( (err) => {
+                let content = document.createElement("p");
+                let contentText= `${err.constructor.name}: ${err.message}` ;
+                content.append(document.createTextNode(contentText));
+
+                contentPanelDiv.append(content);
+            });
+        }
 }
 
 function initializePanels() {


### PR DESCRIPTION
This PR adds code to report all errors on playground startup.

Previous code only reported configuration errors and platform errors, using a specific format, but did not provide a catch-all section reporting any other errors that might occur. This now adds this catch-all block, which will report, for example, parsing errors and errors opening the activitiy file (which closes #128).