### PR TITLE
Correctly report activity access issues

### DIFF
--- a/platform/src/ActivityManager.js
+++ b/platform/src/ActivityManager.js
@@ -123,14 +123,12 @@ class ActivityManager {
         let errors = []; 
         let fileContent
 
-        try{
+        try {
             let file = this.fileHandler.fetchFile( this.activitiesUrl , urlParamPrivateRepo() );
             fileContent = file.content;
         } catch (e) {
-            if (e instanceof DOMException){
-                errors.push( new EducationPlatformError(`The activity configuration file was not accessible at: ${this.activitiesUrl}. 
-                                                        Check the activity file is available at the given url.`) );
-            }
+            errors.push( new EducationPlatformError(`The activity configuration file was not accessible at: ${this.activitiesUrl}. 
+                                                    Check the activity file is available at the given url and you have the correct access rights.`) );
         }
 
         if (fileContent != null){

--- a/tokenserver/src/middleware/ErrorHandlingMiddleware.js
+++ b/tokenserver/src/middleware/ErrorHandlingMiddleware.js
@@ -2,8 +2,8 @@
 
 const errorHandlingMiddleware = (err, req, res, next) => {
   if (err.status != null) {
-    res.status(err.statusCode).json({
-        msg: err.message,
+    res.status(err.status).json({
+        msg: err.response.data.message,
         success: false,
       });
   } else {


### PR DESCRIPTION
This PR fixes a problem whereby accessing a non-existing activities.json or a file where the permissions were missing would not lead to an error being reported to the user but would quietly crash the token server and the platform.

In the PR, the token server correctly reports the issue and the platform correctly raises an error to the user rather than trying to process the activity specification.