### PR TITLE
Unit tests for ActivityManager

### DIFF
--- a/platform/src/ActivityManager.js
+++ b/platform/src/ActivityManager.js
@@ -3,6 +3,7 @@
 import { urlParamPrivateRepo, parseConfigFile } from "./Utility.js";
 import { ActivityConfigValidator } from "./ActivityConfigValidator.js";
 import { EducationPlatformError } from "./EducationPlatformError.js";
+import {utility} from "./Utility.js"
 
 const NAV_ID_PREFIX = "nav-entry-";
 
@@ -32,7 +33,7 @@ class ActivityManager {
         this.fileHandler = fileHandler;
 
         // Retrieve the url of the activities configuration
-        var parameters = new URLSearchParams(window.location.search);
+        var parameters = new URLSearchParams(utility.getWindowLocationSearch());
         if (parameters.has("activities")) {
             this.customActivitiesUrl = true;
             this.activitiesUrl = parameters.get("activities");
@@ -48,15 +49,19 @@ class ActivityManager {
                 break;
             }
         }
+    }
 
+    /**
+     *  Intialises activities by fetching the activities from the activitiesUrl 
+     *  remote and resolving action references.
+     */
+    initializeActivities(){
         this.configErrors = this.configErrors.concat(this.fetchActivities());
 
         for(var activityKey of Object.keys(this.activities)) {
             this.resolveActionReferences( this.activities[activityKey].id );
         }
     }
-
-
 
     resolveActionReferences(activityId){
         

--- a/platform/src/Playground.js
+++ b/platform/src/Playground.js
@@ -140,6 +140,7 @@ function initializeActivity(){
         // An activity configuration has been provided
         toolsManager = new ToolsManager();
         activityManager = new ActivityManager( (toolsManager.getPanelDefinition).bind(toolsManager), fileHandler );
+        activityManager.initializeActivities();
         errors = errors.concat(activityManager.getConfigErrors());
     } 
 

--- a/platform/src/Utility.js
+++ b/platform/src/Utility.js
@@ -208,3 +208,24 @@ export function parseConfigFile(contents, extension="yml"){
 
     return configObject;
 }
+
+/**
+ * Gets query string of the current url - window.location.search.
+ * @returns {string} the query string
+ */
+export function getWindowLocationSearch(){
+    return window.location.search;
+}
+
+/* ES6 Direct imports cannot be stubbed during unit test. Therefore, to enable unit testing 
+   access to functions has to be made using the utility object.  */
+export const utility = {
+    arrayEquals,
+    jsonRequest,
+    jsonRequestConversion,
+    getRequest,
+    urlParamPrivateRepo,
+    isAuthenticated,
+    parseConfigFile,
+    getWindowLocationSearch
+}

--- a/platform/test/resources/TestActivityFiles.js
+++ b/platform/test/resources/TestActivityFiles.js
@@ -15,12 +15,14 @@ export const ACTIVITY_2PANELS_1ACTION = `{
                 {
                     "id": "panel-1",
                     "name": "Panel 1",
-                    "ref": "x"
+                    "ref": "paneldef-t1",
+                    "file": "file1.ext"
                 },
                 {
                     "id": "panel-2",
                     "name": "Panel 2",
-                    "ref": "x"
+                    "ref": "paneldef-t1",
+                    "file": "file2.ext"
                 }
             ],
             "actions": [

--- a/platform/test/resources/TestActivityFiles.js
+++ b/platform/test/resources/TestActivityFiles.js
@@ -1,0 +1,38 @@
+
+export const ACTIVITY_2PANELS_1ACTION = `{
+    "activities": [
+        {
+            "id": "activity-1",
+            "title": "Activity 1",
+            "icon": "icon",
+            "tools": ["test://t.url"],
+            "layout": {
+                "area": [
+                    ["panel-1"]
+                ]
+            },
+            "panels": [
+                {
+                    "id": "panel-1",
+                    "name": "Panel 1",
+                    "ref": "x"
+                },
+                {
+                    "id": "panel-2",
+                    "name": "Panel 2",
+                    "ref": "x"
+                }
+            ],
+            "actions": [
+                {
+                    "source": "panel-1",
+                    "sourceButton": "button-1",
+                    "parameters": {
+                        "parameter1": "panel-1"
+                    },
+                    "output": "panel-2"                   
+                }
+            ]
+        }
+    ]
+}`

--- a/platform/test/resources/TestToolFiles.js
+++ b/platform/test/resources/TestToolFiles.js
@@ -1,0 +1,46 @@
+export const TOOL_1PANELDEF_1FUNCTION = `{
+    "tool": 
+        {
+            "id": "tool-1",
+            "name": "Tool 1",
+            "version": "0.0.0",
+            "author": "Test",
+            "homepage": "test://t.url",
+            "functions": [
+                {
+                    "id": "function-1",
+                    "name": "Function 1",
+                    "parameters": [ {"name":"parameter1", "type":"type1"}, 
+                                    {"name":"paremeter2", "type":"type2"}, 
+                                    {"name":"language", "type":"string"} ],
+    
+                    "returnType": "text",
+                    "path": "test://tool1.url"
+                }
+            ],
+            "panelDefs": [
+                {
+                    "id": "paneldef-t1",
+                    "name": "Panel Definition Tool 1",
+                    "panelclass": "ProgramPanel",
+                    "icon": "icon",
+                    "language": "test",
+                    "buttons" : [
+                        {
+                          "id": "action-button",
+                          "icon": "run",
+                          "actionfunction": "function-1",
+                          "hint": "Run the program"
+                        },
+                        {
+                          "id": "help-button",
+                          "icon": "info",
+                          "url": "test://t1.url/help",
+                          "hint": "Tool 1 Help"
+                        }
+                    ]
+                }
+            ]
+        }
+} 
+`

--- a/platform/test/resources/TestUtility.js
+++ b/platform/test/resources/TestUtility.js
@@ -11,12 +11,3 @@ export function configObjectEquals(configA, configB){
 
     return (strConfigA === strConfigB)
 }
-
-/**
- * Prints a configuration object including its values.
- * @param {Object} config 
- * @returns {string} the string representation
- */
-export function configToString (config) {
-    return JSON.stringify(config);
-}

--- a/platform/test/resources/TestUtility.js
+++ b/platform/test/resources/TestUtility.js
@@ -1,0 +1,22 @@
+/**
+ * Compares two configuration objects. 
+ * @param {Object} configA
+ * @param {Object} configB
+ * @returns {Boolean} true if the objects values are equal.
+ */
+export function configObjectEquals(configA, configB){
+
+    const strConfigA = JSON.stringify(configA);
+    const strConfigB = JSON.stringify(configB);
+
+    return (strConfigA === strConfigB)
+}
+
+/**
+ * Prints a configuration object including its values.
+ * @param {Object} config 
+ * @returns {string} the string representation
+ */
+export function configToString (config) {
+    return JSON.stringify(config);
+}

--- a/platform/test/spec/testActivityManagerSpec.js
+++ b/platform/test/spec/testActivityManagerSpec.js
@@ -1,0 +1,133 @@
+/*global describe, it, expect, spyOn --  functions provided by Jasmine */
+import {ActivityManager} from "../../src/ActivityManager.js";
+
+import { FileHandler } from "../../src/FileHandler.js";
+import { ActivityConfigValidator } from "../../src/ActivityConfigValidator.js";
+import { utility } from "../../src/Utility.js";
+
+
+
+describe("ActivityManager", () => {
+
+        it("can be created", () => {
+            // Setup
+            const fileh = new FileHandler("test://th.url") 
+            const refPanelDef = () => {};
+                
+            // Call the target object
+            var am = new ActivityManager(refPanelDef , fileh);
+ 
+            // Check the expected results
+            expect(am).toBeInstanceOf(ActivityManager);
+        })
+ 
+        it("constructor -  initialises the configValidator property", () => {
+            // Setup
+            const fileh = new FileHandler("test://th.url") 
+            const refPanelDef = () => {};
+
+            // Call the target object
+            var am = new ActivityManager(refPanelDef , fileh);
+
+            // Check the expected results
+            expect(am.configValidator).toBeInstanceOf(ActivityConfigValidator);
+        })        
+
+        it("constructor -  initialises the accessPanelDef property using param panelDefAccessor", () => {
+            // Setup
+            const fileh = new FileHandler("test://th.url") 
+            const refPanelDef = () => {};
+
+            // Call the target object
+            var am = new ActivityManager(refPanelDef , fileh);
+
+            // Check the expected results
+            expect(am.accessPanelDef).toBe(refPanelDef);
+        })  
+
+        it("constructor -  initialises the fileHandler property  using param fileHandler", () => {
+            // Setup
+            const fileh = new FileHandler("test://th.url") 
+            const refPanelDef = () => {};
+
+            // Call the target object
+            var am = new ActivityManager(refPanelDef , fileh);
+
+            // Check the expected results
+            expect(am.fileHandler).toBe(fileh);
+        })  
+
+        it("constructor -  uses the query string to set the activitiesUrl property", () => {
+            // Setup
+            const ACTIVITY_URL="test://a.url";
+            const QUERY = "?activities=" + ACTIVITY_URL;
+            const fileh = new FileHandler("test://th.url") 
+            const refPanelDef = () => {};
+
+            spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
+
+            // Call the target object
+            var am = new ActivityManager(refPanelDef , fileh);
+
+            // Check the expected results
+            expect(utility.getWindowLocationSearch).toHaveBeenCalled();
+            expect(am.activitiesUrl).toBe(ACTIVITY_URL);
+        })
+
+        it ("constructor -  if the current activity is provided in the url query string, set the activityId property", () => {
+            // Setup
+            const ACTIVITY_URL="test://a.url";
+            const ACTIVITY_ID="a1"
+            const QUERY = "?"+ ACTIVITY_ID + "=&" + "activities=" + ACTIVITY_URL;
+            const fileh = new FileHandler("test://th.url") 
+            const refPanelDef = () => {};
+
+            spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
+
+            // Call the target object
+            var am = new ActivityManager(refPanelDef , fileh);
+
+            // Check the expected results
+            expect(am.activityId).toBe(ACTIVITY_ID);
+        })
+
+        it("initializeActivities - causes the activity file to be fetched from its URL using the fileHandler", () => {
+            // Setup
+            const ACTIVITY_URL="test://a.url";
+            const QUERY="?activities=" + ACTIVITY_URL;
+            const fileh = new FileHandler(ACTIVITY_URL) 
+            const refPanelDef = () => {};
+
+            spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
+            spyOn(FileHandler.prototype, "fetchFile").and.returnValue({ content: {} });
+            
+            // Call the target object
+            var am = new ActivityManager(refPanelDef , fileh);
+            am.initializeActivities();
+
+            // Check the expected results
+            expect(FileHandler.prototype.fetchFile).toHaveBeenCalledWith(ACTIVITY_URL, false);
+        } )
+
+        it("initializeActivities - Resolves references for a valid activity by  calling resolveActionReferences with activity id", ()=> {
+            // Setup
+            const fileh = new FileHandler("test://th.url") 
+            const refPanelDef = () => {};
+            const ACTIVITY_ID = "a1";
+            const activityObject = {
+                a1: {id: ACTIVITY_ID}
+            };
+
+            //spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
+            spyOn( ActivityManager.prototype, "fetchActivities").and.returnValue([]);
+            spyOn( ActivityManager.prototype, "resolveActionReferences");
+
+            // Call the target object
+            var am = new ActivityManager(refPanelDef , fileh);
+            am.activities = activityObject;
+            am.initializeActivities();
+
+            // Check the expected results
+            expect(am.resolveActionReferences).toHaveBeenCalledWith(ACTIVITY_ID);
+        })
+})

--- a/platform/test/spec/testActivityManagerSpec.js
+++ b/platform/test/spec/testActivityManagerSpec.js
@@ -4,8 +4,9 @@ import {ActivityManager} from "../../src/ActivityManager.js";
 import { FileHandler } from "../../src/FileHandler.js";
 import { ActivityConfigValidator } from "../../src/ActivityConfigValidator.js";
 import { utility } from "../../src/Utility.js";
-import { ACTIVITY_2PANELS_1ACTION } from "../resources/TestActivityFiles.js"
-import { configObjectEquals, configToString } from "../resources/TestUtility.js"
+import { ACTIVITY_2PANELS_1ACTION } from "../resources/TestActivityFiles.js";
+import { TOOL_1PANELDEF_1FUNCTION } from "../resources/TestToolFiles.js";
+import { configObjectEquals, configToString } from "../resources/TestUtility.js";
 
 
 describe("ActivityManager", () => {
@@ -157,6 +158,7 @@ describe("ActivityManager", () => {
         const ACTIVITY_ID = "activity-1";
         const PANEL1_ID = "panel-1";
         const PANEL2_ID = "panel-2";
+        const PANEL_DEINITION_ID = "paneldef-t1";
 
         it("current activity activityId property is set to the activity id", () => {
             expect(am.activityId).toEqual(ACTIVITY_ID);
@@ -175,34 +177,88 @@ describe("ActivityManager", () => {
             expect(am.activities[ACTIVITY_ID]).toBeInstanceOf(Object);
         }) 
 
-        it("the activities property's value object has required keys", () => {
-            const EXPECTED_KEYS = ["actions", "icon", "id", "layout", "panels", "title", "tools"];
+        it("the activities property is an object that has required keys", () => {
+            const REQUIRED_KEYS = ["actions", "icon", "id", "layout", "panels", "title", "tools"];
   
             const activityObject = am.activities[ACTIVITY_ID];
             let parsedActivityKeys = Object.keys(activityObject);
 
-            expect(parsedActivityKeys).toHaveSize(EXPECTED_KEYS.length)
-            for(const k of EXPECTED_KEYS){
+            expect(parsedActivityKeys).toHaveSize(REQUIRED_KEYS.length)
+            for(const k of REQUIRED_KEYS){
                 if ( !parsedActivityKeys.find( (n) => (n == k) ) ){
                     fail("Expected key '" + k + "' not found in activity object.");
                 }
             }
         }) 
 
-        it("the activities property's value object action panels are resolved", () => {
+        it("the activities actions property panel references have been resolved", () => {
             const expectedActivity = JSON.parse(activityFile).activities[0];
             const expectedPanelSource = expectedActivity.panels.find((p) => p.id===PANEL1_ID);
             const expectedPanelOutput = expectedActivity.panels.find((p) => p.id===PANEL2_ID);
             
             const action = am.activities[ACTIVITY_ID].actions[0];
             
+            expect(action.source).toBeInstanceOf(Object);
             if (!configObjectEquals( action.source, expectedPanelSource )) {
                 fail("Expected action's source panel'" + configToString(action.source) + "' to equal'" + configToString(expectedPanelSource) + "'");
             }
 
+            expect(action.output).toBeInstanceOf(Object);
             if (!configObjectEquals( action.output, expectedPanelOutput )){
                 fail("Expected action's source panel'" + configToString(action.output) + "' to equal'" + configToString(expectedPanelOutput) + "'" );
             }
         })
+
+        it("the panel definitions the current activity references are unresolved", () => {
+            expect (am.activities[ACTIVITY_ID].panels[0].ref).toEqual(PANEL_DEINITION_ID);
+            expect (am.activities[ACTIVITY_ID].panels[1].ref).toEqual(PANEL_DEINITION_ID);
+        })
+    })
+
+
+    describe("getting current activity", () => {
+        const ACTIVITY_URL="http://a.url";
+        const QUERY="?activities=" + ACTIVITY_URL;
+        let fileh;
+        let refPanelDef;
+        let am;
+        const activityFile = ACTIVITY_2PANELS_1ACTION;
+        const toolConfig = JSON.parse(TOOL_1PANELDEF_1FUNCTION).tool;
+        const panelDef = toolConfig.panelDefs[0];
+
+        beforeEach( () => {
+            // Setup
+            fileh = new FileHandler("test://th.url"); 
+            refPanelDef = () => {
+                return panelDef;
+            };
+                
+            spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
+            spyOn(FileHandler.prototype, "fetchFile").and.returnValue({ content: activityFile });
+            spyOn(ActivityConfigValidator.prototype, "validateConfigFile").and.returnValue([]);
+            spyOn(ActivityManager.prototype, "appendTopLevelActivityMenuItem"); // Uses document.getElementById
+            spyOn(ActivityManager.prototype, "fetchFile").and.returnValue({content: "Test Content", sha: "a123"}); 
+
+            // Call the target object
+            am = new ActivityManager(refPanelDef , fileh);
+            am.initializeActivities();
+            am.getSelectedActivity();
+        }) 
+
+        // Check the expected results
+        const ACTIVITY_ID = "activity-1";
+
+        it("the panel definitions for the current activity references are resolved", () => {
+            expect(am.activities[ACTIVITY_ID].panels[0].ref).toBeInstanceOf(Object);
+            expect(am.activities[ACTIVITY_ID].panels[0].ref).toEqual(toolConfig.panelDefs[0])
+
+            expect(am.activities[ACTIVITY_ID].panels[1].ref).toBeInstanceOf(Object);
+            expect(am.activities[ACTIVITY_ID].panels[1].ref).toEqual(toolConfig.panelDefs[0]);
+        })
+
+        it("the activity files are fetched using FileHandler", () => {
+            expect(am.fetchFile.calls.allArgs()).toEqual( [["file1.ext"],  ["file2.ext"] ]);
+        })
+
     })
 })

--- a/platform/test/spec/testActivityManagerSpec.js
+++ b/platform/test/spec/testActivityManagerSpec.js
@@ -6,91 +6,67 @@ import { ActivityConfigValidator } from "../../src/ActivityConfigValidator.js";
 import { utility } from "../../src/Utility.js";
 import { ACTIVITY_2PANELS_1ACTION } from "../resources/TestActivityFiles.js";
 import { TOOL_1PANELDEF_1FUNCTION } from "../resources/TestToolFiles.js";
-import { configObjectEquals, configToString } from "../resources/TestUtility.js";
+import { configObjectEquals } from "../resources/TestUtility.js";
 
 
 describe("ActivityManager", () => {
 
-    it("can be created", () => {
-        // Setup
-        const fileh = new FileHandler("test://th.url") 
-        const refPanelDef = () => {};
-            
-        // Call the target object
-        var am = new ActivityManager(refPanelDef , fileh);
-
-        // Check the expected results
-        expect(am).toBeInstanceOf(ActivityManager);
-    })
-
-    it("constructor -  initialises the configValidator property", () => {
-        // Setup
-        const fileh = new FileHandler("test://th.url") 
-        const refPanelDef = () => {};
-
-        // Call the target object
-        var am = new ActivityManager(refPanelDef , fileh);
-
-        // Check the expected results
-        expect(am.configValidator).toBeInstanceOf(ActivityConfigValidator);
-    })        
-
-    it("constructor -  initialises the accessPanelDef property using param panelDefAccessor", () => {
-        // Setup
-        const fileh = new FileHandler("test://th.url") 
-        const refPanelDef = () => {};
-
-        // Call the target object
-        var am = new ActivityManager(refPanelDef , fileh);
-
-        // Check the expected results
-        expect(am.accessPanelDef).toBe(refPanelDef);
-    })  
-
-    it("constructor -  initialises the fileHandler property  using param fileHandler", () => {
-        // Setup
-        const fileh = new FileHandler("test://th.url") 
-        const refPanelDef = () => {};
-
-        // Call the target object
-        var am = new ActivityManager(refPanelDef , fileh);
-
-        // Check the expected results
-        expect(am.fileHandler).toBe(fileh);
-    })  
-
-    it("constructor -  uses the query string to set the activitiesUrl property", () => {
+    describe("constructor", () => {
         // Setup
         const ACTIVITY_URL="test://a.url";
-        const QUERY = "?activities=" + ACTIVITY_URL;
-        const fileh = new FileHandler("test://th.url") 
-        const refPanelDef = () => {};
+        let am;
+        let fileh;
+        let refPanelDef;
+        let spySearch;
 
-        spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
+        beforeEach( () => {
 
-        // Call the target object
-        var am = new ActivityManager(refPanelDef , fileh);
+            fileh = new FileHandler("test://th.url") 
+            refPanelDef = () => {};
 
-        // Check the expected results
-        expect(utility.getWindowLocationSearch).toHaveBeenCalled();
-        expect(am.activitiesUrl).toBe(ACTIVITY_URL);
-    })
+            spySearch = spyOn( utility, "getWindowLocationSearch");
 
-    it ("constructor -  if the current activity is provided in the url query string, set the activityId property", () => {
-        // Setup
-        const ACTIVITY_URL="test://a.url";
-        const ACTIVITY_ID="a1"
-        const QUERY = "?"+ ACTIVITY_ID + "=&" + "activities=" + ACTIVITY_URL;
-        const fileh = new FileHandler("test://th.url") 
-        const refPanelDef = () => {};
-
-        spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
-
-        // Call the target object
-        var am = new ActivityManager(refPanelDef , fileh);
+            // Call the target object
+            am = new ActivityManager(refPanelDef, fileh);
+        })
 
         // Check the expected results
-        expect(am.activityId).toBe(ACTIVITY_ID);
+        it("can be created", () => {
+            expect(am).toBeInstanceOf(ActivityManager);
+        })
+
+        it("initialises the configValidator property", () => {
+            expect(am.configValidator).toBeInstanceOf(ActivityConfigValidator);
+        })        
+
+        it("initialises the accessPanelDef property using param panelDefAccessor", () => {
+            expect(am.accessPanelDef).toBe(refPanelDef);
+        })  
+
+        it("initialises the fileHandler property  using param fileHandler", () => {
+            expect(am.fileHandler).toBe(fileh);
+        })  
+
+        it("uses the query string to set the activitiesUrl property", () => {
+            const QUERY = "?activities=" + ACTIVITY_URL;
+            spySearch.and.returnValue(QUERY); //Update the spy
+
+            am = new ActivityManager(refPanelDef, fileh);
+
+            expect(utility.getWindowLocationSearch).toHaveBeenCalled();
+            expect(am.activitiesUrl).toBe(ACTIVITY_URL);
+        })
+
+        it ("if the current activity is provided in the url query string, set the activityId property", () => {
+            const ACTIVITY_ID="a1"
+            const QUERY = "?"+ ACTIVITY_ID + "=&" + "activities=" + ACTIVITY_URL;
+            spySearch.and.returnValue(QUERY); // Update the spy
+
+            am = new ActivityManager(refPanelDef , fileh);
+
+            expect(am.activityId).toBe(ACTIVITY_ID);
+        })
+
     })
 
     it("initializeActivities - causes the activity file to be fetched from its URL using the fileHandler", () => {
@@ -200,12 +176,12 @@ describe("ActivityManager", () => {
             
             expect(action.source).toBeInstanceOf(Object);
             if (!configObjectEquals( action.source, expectedPanelSource )) {
-                fail("Expected action's source panel'" + configToString(action.source) + "' to equal'" + configToString(expectedPanelSource) + "'");
+                fail("Expected action's source panel'" + JSON.stringify(action.source) + "' to equal'" + JSON.stringify(expectedPanelSource) + "'");
             }
 
             expect(action.output).toBeInstanceOf(Object);
             if (!configObjectEquals( action.output, expectedPanelOutput )){
-                fail("Expected action's source panel'" + configToString(action.output) + "' to equal'" + configToString(expectedPanelOutput) + "'" );
+                fail("Expected action's source panel'" + JSON.stringify(action.output) + "' to equal'" + JSON.stringify(expectedPanelOutput) + "'" );
             }
         })
 

--- a/platform/test/spec/testActivityManagerSpec.js
+++ b/platform/test/spec/testActivityManagerSpec.js
@@ -1,133 +1,208 @@
-/*global describe, it, expect, spyOn --  functions provided by Jasmine */
+/*global describe, it, expect, spyOn, beforeEach, fail --  functions provided by Jasmine */
 import {ActivityManager} from "../../src/ActivityManager.js";
 
 import { FileHandler } from "../../src/FileHandler.js";
 import { ActivityConfigValidator } from "../../src/ActivityConfigValidator.js";
 import { utility } from "../../src/Utility.js";
-
+import { ACTIVITY_2PANELS_1ACTION } from "../resources/TestActivityFiles.js"
+import { configObjectEquals, configToString } from "../resources/TestUtility.js"
 
 
 describe("ActivityManager", () => {
 
-        it("can be created", () => {
-            // Setup
-            const fileh = new FileHandler("test://th.url") 
-            const refPanelDef = () => {};
-                
-            // Call the target object
-            var am = new ActivityManager(refPanelDef , fileh);
- 
-            // Check the expected results
-            expect(am).toBeInstanceOf(ActivityManager);
-        })
- 
-        it("constructor -  initialises the configValidator property", () => {
-            // Setup
-            const fileh = new FileHandler("test://th.url") 
-            const refPanelDef = () => {};
-
-            // Call the target object
-            var am = new ActivityManager(refPanelDef , fileh);
-
-            // Check the expected results
-            expect(am.configValidator).toBeInstanceOf(ActivityConfigValidator);
-        })        
-
-        it("constructor -  initialises the accessPanelDef property using param panelDefAccessor", () => {
-            // Setup
-            const fileh = new FileHandler("test://th.url") 
-            const refPanelDef = () => {};
-
-            // Call the target object
-            var am = new ActivityManager(refPanelDef , fileh);
-
-            // Check the expected results
-            expect(am.accessPanelDef).toBe(refPanelDef);
-        })  
-
-        it("constructor -  initialises the fileHandler property  using param fileHandler", () => {
-            // Setup
-            const fileh = new FileHandler("test://th.url") 
-            const refPanelDef = () => {};
-
-            // Call the target object
-            var am = new ActivityManager(refPanelDef , fileh);
-
-            // Check the expected results
-            expect(am.fileHandler).toBe(fileh);
-        })  
-
-        it("constructor -  uses the query string to set the activitiesUrl property", () => {
-            // Setup
-            const ACTIVITY_URL="test://a.url";
-            const QUERY = "?activities=" + ACTIVITY_URL;
-            const fileh = new FileHandler("test://th.url") 
-            const refPanelDef = () => {};
-
-            spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
-
-            // Call the target object
-            var am = new ActivityManager(refPanelDef , fileh);
-
-            // Check the expected results
-            expect(utility.getWindowLocationSearch).toHaveBeenCalled();
-            expect(am.activitiesUrl).toBe(ACTIVITY_URL);
-        })
-
-        it ("constructor -  if the current activity is provided in the url query string, set the activityId property", () => {
-            // Setup
-            const ACTIVITY_URL="test://a.url";
-            const ACTIVITY_ID="a1"
-            const QUERY = "?"+ ACTIVITY_ID + "=&" + "activities=" + ACTIVITY_URL;
-            const fileh = new FileHandler("test://th.url") 
-            const refPanelDef = () => {};
-
-            spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
-
-            // Call the target object
-            var am = new ActivityManager(refPanelDef , fileh);
-
-            // Check the expected results
-            expect(am.activityId).toBe(ACTIVITY_ID);
-        })
-
-        it("initializeActivities - causes the activity file to be fetched from its URL using the fileHandler", () => {
-            // Setup
-            const ACTIVITY_URL="test://a.url";
-            const QUERY="?activities=" + ACTIVITY_URL;
-            const fileh = new FileHandler(ACTIVITY_URL) 
-            const refPanelDef = () => {};
-
-            spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
-            spyOn(FileHandler.prototype, "fetchFile").and.returnValue({ content: {} });
+    it("can be created", () => {
+        // Setup
+        const fileh = new FileHandler("test://th.url") 
+        const refPanelDef = () => {};
             
-            // Call the target object
-            var am = new ActivityManager(refPanelDef , fileh);
-            am.initializeActivities();
+        // Call the target object
+        var am = new ActivityManager(refPanelDef , fileh);
 
-            // Check the expected results
-            expect(FileHandler.prototype.fetchFile).toHaveBeenCalledWith(ACTIVITY_URL, false);
-        } )
+        // Check the expected results
+        expect(am).toBeInstanceOf(ActivityManager);
+    })
 
-        it("initializeActivities - Resolves references for a valid activity by  calling resolveActionReferences with activity id", ()=> {
+    it("constructor -  initialises the configValidator property", () => {
+        // Setup
+        const fileh = new FileHandler("test://th.url") 
+        const refPanelDef = () => {};
+
+        // Call the target object
+        var am = new ActivityManager(refPanelDef , fileh);
+
+        // Check the expected results
+        expect(am.configValidator).toBeInstanceOf(ActivityConfigValidator);
+    })        
+
+    it("constructor -  initialises the accessPanelDef property using param panelDefAccessor", () => {
+        // Setup
+        const fileh = new FileHandler("test://th.url") 
+        const refPanelDef = () => {};
+
+        // Call the target object
+        var am = new ActivityManager(refPanelDef , fileh);
+
+        // Check the expected results
+        expect(am.accessPanelDef).toBe(refPanelDef);
+    })  
+
+    it("constructor -  initialises the fileHandler property  using param fileHandler", () => {
+        // Setup
+        const fileh = new FileHandler("test://th.url") 
+        const refPanelDef = () => {};
+
+        // Call the target object
+        var am = new ActivityManager(refPanelDef , fileh);
+
+        // Check the expected results
+        expect(am.fileHandler).toBe(fileh);
+    })  
+
+    it("constructor -  uses the query string to set the activitiesUrl property", () => {
+        // Setup
+        const ACTIVITY_URL="test://a.url";
+        const QUERY = "?activities=" + ACTIVITY_URL;
+        const fileh = new FileHandler("test://th.url") 
+        const refPanelDef = () => {};
+
+        spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
+
+        // Call the target object
+        var am = new ActivityManager(refPanelDef , fileh);
+
+        // Check the expected results
+        expect(utility.getWindowLocationSearch).toHaveBeenCalled();
+        expect(am.activitiesUrl).toBe(ACTIVITY_URL);
+    })
+
+    it ("constructor -  if the current activity is provided in the url query string, set the activityId property", () => {
+        // Setup
+        const ACTIVITY_URL="test://a.url";
+        const ACTIVITY_ID="a1"
+        const QUERY = "?"+ ACTIVITY_ID + "=&" + "activities=" + ACTIVITY_URL;
+        const fileh = new FileHandler("test://th.url") 
+        const refPanelDef = () => {};
+
+        spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
+
+        // Call the target object
+        var am = new ActivityManager(refPanelDef , fileh);
+
+        // Check the expected results
+        expect(am.activityId).toBe(ACTIVITY_ID);
+    })
+
+    it("initializeActivities - causes the activity file to be fetched from its URL using the fileHandler", () => {
+        // Setup
+        const ACTIVITY_URL="test://a.url";
+        const QUERY="?activities=" + ACTIVITY_URL;
+        const fileh = new FileHandler(ACTIVITY_URL) 
+        const refPanelDef = () => {};
+
+        spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
+        spyOn(FileHandler.prototype, "fetchFile").and.returnValue({ content: {} });
+        
+        // Call the target object
+        var am = new ActivityManager(refPanelDef , fileh);
+        am.initializeActivities();
+
+        // Check the expected results
+        expect(FileHandler.prototype.fetchFile).toHaveBeenCalledWith(ACTIVITY_URL, false);
+    } )
+
+    it("initializeActivities - Resolves references for a valid activity by  calling resolveActionReferences with activity id", ()=> {
+        // Setup
+        const fileh = new FileHandler("test://th.url") 
+        const refPanelDef = () => {};
+        const ACTIVITY_ID = "a1";
+        const activityObject = {
+            a1: {id: ACTIVITY_ID}
+        };
+
+        //spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
+        spyOn( ActivityManager.prototype, "fetchActivities").and.returnValue([]);
+        spyOn( ActivityManager.prototype, "resolveActionReferences");
+
+        // Call the target object
+        var am = new ActivityManager(refPanelDef , fileh);
+        am.activities = activityObject;
+        am.initializeActivities();
+
+        // Check the expected results
+        expect(am.resolveActionReferences).toHaveBeenCalledWith(ACTIVITY_ID);
+    })
+    
+
+    describe("activity initialisation", () => {
+        let fileh;
+        let refPanelDef;
+        let am;
+        const activityFile = ACTIVITY_2PANELS_1ACTION;
+
+        beforeEach( () => {
             // Setup
-            const fileh = new FileHandler("test://th.url") 
-            const refPanelDef = () => {};
-            const ACTIVITY_ID = "a1";
-            const activityObject = {
-                a1: {id: ACTIVITY_ID}
-            };
-
-            //spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
-            spyOn( ActivityManager.prototype, "fetchActivities").and.returnValue([]);
-            spyOn( ActivityManager.prototype, "resolveActionReferences");
+            fileh = new FileHandler("test://th.url"); 
+            refPanelDef = () => {};
+                
+            spyOn(FileHandler.prototype, "fetchFile").and.returnValue({ content: activityFile });
+            spyOn(ActivityConfigValidator.prototype, "validateConfigFile").and.returnValue([]);
+            spyOn(ActivityManager.prototype, "appendTopLevelActivityMenuItem"); // Uses document.getElementById
 
             // Call the target object
-            var am = new ActivityManager(refPanelDef , fileh);
-            am.activities = activityObject;
+            am = new ActivityManager(refPanelDef , fileh);
             am.initializeActivities();
-
-            // Check the expected results
-            expect(am.resolveActionReferences).toHaveBeenCalledWith(ACTIVITY_ID);
         })
+
+        // Check the expected results
+        const ACTIVITY_ID = "activity-1";
+        const PANEL1_ID = "panel-1";
+        const PANEL2_ID = "panel-2";
+
+        it("current activity activityId property is set to the activity id", () => {
+            expect(am.activityId).toEqual(ACTIVITY_ID);
+        })
+
+        it("no config errors empty configErrors propererty", () => {
+            expect(am.configErrors).toHaveSize(0);
+        })
+
+        it("the activities property has a key matching the activity id", () => {
+            expect(Object.keys(am.activities)).toHaveSize(1);
+            expect(Object.keys(am.activities).pop()).toEqual(ACTIVITY_ID);
+        })
+
+        it("an activities property's value is an object", () => {
+            expect(am.activities[ACTIVITY_ID]).toBeInstanceOf(Object);
+        }) 
+
+        it("the activities property's value object has required keys", () => {
+            const EXPECTED_KEYS = ["actions", "icon", "id", "layout", "panels", "title", "tools"];
+  
+            const activityObject = am.activities[ACTIVITY_ID];
+            let parsedActivityKeys = Object.keys(activityObject);
+
+            expect(parsedActivityKeys).toHaveSize(EXPECTED_KEYS.length)
+            for(const k of EXPECTED_KEYS){
+                if ( !parsedActivityKeys.find( (n) => (n == k) ) ){
+                    fail("Expected key '" + k + "' not found in activity object.");
+                }
+            }
+        }) 
+
+        it("the activities property's value object action panels are resolved", () => {
+            const expectedActivity = JSON.parse(activityFile).activities[0];
+            const expectedPanelSource = expectedActivity.panels.find((p) => p.id===PANEL1_ID);
+            const expectedPanelOutput = expectedActivity.panels.find((p) => p.id===PANEL2_ID);
+            
+            const action = am.activities[ACTIVITY_ID].actions[0];
+            
+            if (!configObjectEquals( action.source, expectedPanelSource )) {
+                fail("Expected action's source panel'" + configToString(action.source) + "' to equal'" + configToString(expectedPanelSource) + "'");
+            }
+
+            if (!configObjectEquals( action.output, expectedPanelOutput )){
+                fail("Expected action's source panel'" + configToString(action.output) + "' to equal'" + configToString(expectedPanelOutput) + "'" );
+            }
+        })
+    })
 })

--- a/platform/test/spec/testActivityManagerSpec.js
+++ b/platform/test/spec/testActivityManagerSpec.js
@@ -57,7 +57,7 @@ describe("ActivityManager", () => {
             expect(am.activitiesUrl).toBe(ACTIVITY_URL);
         })
 
-        it ("if the current activity is provided in the url query string, set the activityId property", () => {
+        it ("sets the activityId property if the current activity is provided in the url query string", () => {
             const ACTIVITY_ID="a1"
             const QUERY = "?"+ ACTIVITY_ID + "=&" + "activities=" + ACTIVITY_URL;
             spySearch.and.returnValue(QUERY); // Update the spy

--- a/platform/test/spec/testActivityManagerSpec.js
+++ b/platform/test/spec/testActivityManagerSpec.js
@@ -14,7 +14,6 @@ describe("ActivityManager", () => {
     describe("constructor", () => {
         // Setup
         const ACTIVITY_URL="test://a.url";
-        let am;
         let fileh;
         let refPanelDef;
         let spySearch;
@@ -25,25 +24,37 @@ describe("ActivityManager", () => {
             refPanelDef = () => {};
 
             spySearch = spyOn( utility, "getWindowLocationSearch");
-
-            // Call the target object
-            am = new ActivityManager(refPanelDef, fileh);
         })
 
-        // Check the expected results
         it("can be created", () => {
+            // Call the target object
+            let am = new ActivityManager(refPanelDef, fileh);
+
+            // Check the expected results
             expect(am).toBeInstanceOf(ActivityManager);
         })
 
         it("initialises the configValidator property", () => {
+            // Call the target object
+            let am = new ActivityManager(refPanelDef, fileh);
+
+            // Check the expected results            
             expect(am.configValidator).toBeInstanceOf(ActivityConfigValidator);
         })        
 
         it("initialises the accessPanelDef property using param panelDefAccessor", () => {
+            // Call the target object
+            let am = new ActivityManager(refPanelDef, fileh);
+
+            // Check the expected results            
             expect(am.accessPanelDef).toBe(refPanelDef);
         })  
 
         it("initialises the fileHandler property  using param fileHandler", () => {
+            // Call the target object
+            let am = new ActivityManager(refPanelDef, fileh);
+
+            // Check the expected results            
             expect(am.fileHandler).toBe(fileh);
         })  
 
@@ -51,8 +62,10 @@ describe("ActivityManager", () => {
             const QUERY = "?activities=" + ACTIVITY_URL;
             spySearch.and.returnValue(QUERY); //Update the spy
 
-            am = new ActivityManager(refPanelDef, fileh);
+            // Call the target object
+            let am = new ActivityManager(refPanelDef, fileh);
 
+            // Check the expected results
             expect(utility.getWindowLocationSearch).toHaveBeenCalled();
             expect(am.activitiesUrl).toBe(ACTIVITY_URL);
         })
@@ -62,55 +75,18 @@ describe("ActivityManager", () => {
             const QUERY = "?"+ ACTIVITY_ID + "=&" + "activities=" + ACTIVITY_URL;
             spySearch.and.returnValue(QUERY); // Update the spy
 
-            am = new ActivityManager(refPanelDef , fileh);
+            // Call the target object
+            let am = new ActivityManager(refPanelDef, fileh);
 
+            // Check the expected results
             expect(am.activityId).toBe(ACTIVITY_ID);
         })
 
     })
 
-    it("initializeActivities - causes the activity file to be fetched from its URL using the fileHandler", () => {
-        // Setup
+    describe("activity initialisation", () => {
         const ACTIVITY_URL="test://a.url";
         const QUERY="?activities=" + ACTIVITY_URL;
-        const fileh = new FileHandler(ACTIVITY_URL) 
-        const refPanelDef = () => {};
-
-        spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
-        spyOn(FileHandler.prototype, "fetchFile").and.returnValue({ content: {} });
-        
-        // Call the target object
-        var am = new ActivityManager(refPanelDef , fileh);
-        am.initializeActivities();
-
-        // Check the expected results
-        expect(FileHandler.prototype.fetchFile).toHaveBeenCalledWith(ACTIVITY_URL, false);
-    } )
-
-    it("initializeActivities - Resolves references for a valid activity by  calling resolveActionReferences with activity id", ()=> {
-        // Setup
-        const fileh = new FileHandler("test://th.url") 
-        const refPanelDef = () => {};
-        const ACTIVITY_ID = "a1";
-        const activityObject = {
-            a1: {id: ACTIVITY_ID}
-        };
-
-        //spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
-        spyOn( ActivityManager.prototype, "fetchActivities").and.returnValue([]);
-        spyOn( ActivityManager.prototype, "resolveActionReferences");
-
-        // Call the target object
-        var am = new ActivityManager(refPanelDef , fileh);
-        am.activities = activityObject;
-        am.initializeActivities();
-
-        // Check the expected results
-        expect(am.resolveActionReferences).toHaveBeenCalledWith(ACTIVITY_ID);
-    })
-    
-
-    describe("activity initialisation", () => {
         let fileh;
         let refPanelDef;
         let am;
@@ -121,6 +97,8 @@ describe("ActivityManager", () => {
             fileh = new FileHandler("test://th.url"); 
             refPanelDef = () => {};
                 
+            spyOn( ActivityManager.prototype, "resolveActionReferences").and.callThrough();
+            spyOn( utility, "getWindowLocationSearch").and.returnValue(QUERY);
             spyOn(FileHandler.prototype, "fetchFile").and.returnValue({ content: activityFile });
             spyOn(ActivityConfigValidator.prototype, "validateConfigFile").and.returnValue([]);
             spyOn(ActivityManager.prototype, "appendTopLevelActivityMenuItem"); // Uses document.getElementById
@@ -135,6 +113,14 @@ describe("ActivityManager", () => {
         const PANEL1_ID = "panel-1";
         const PANEL2_ID = "panel-2";
         const PANEL_DEINITION_ID = "paneldef-t1";
+
+        it("causes the activity file to be fetched from its URL using the fileHandler", () => {
+            expect(FileHandler.prototype.fetchFile).toHaveBeenCalledWith(ACTIVITY_URL, false);
+        })
+
+        it("resolves references for a valid activity by  calling resolveActionReferences with activity id", ()=> {
+            expect(am.resolveActionReferences).toHaveBeenCalledWith(ACTIVITY_ID);
+        })
 
         it("current activity activityId property is set to the activity id", () => {
             expect(am.activityId).toEqual(ACTIVITY_ID);


### PR DESCRIPTION
Some unit tests for ActivityManager.

A couple of minor changes were required for test-ability:

- Calls to global browser objects `document` and `window` should be via utility functions that can be stubbed.
- Imports have to be via objects and not direct export.  This is because ES6 protects exports which prevents them being spied on by Jasmine. It is a problem for all javascript test frameworks.
- ActivityManager constructor made costly http requests so these were separated out into initializeActivities() method that's called after it's created.

Code coverage for the module at approx 52%