### PR TITLE
Unit tests for ToolManager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5225,6 +5225,12 @@
         "jasmine": "bin/jasmine.js"
       }
     },
+    "node_modules/jasmine-ajax": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-ajax/-/jasmine-ajax-4.0.0.tgz",
+      "integrity": "sha512-htTxNw38BSHxxmd8RRMejocdPqLalGHU6n3HWFbzp/S8AuTQd1MYjkSH3dYDsbZ7EV1Xqx/b94m3tKaVSVBV2A==",
+      "dev": true
+    },
     "node_modules/jasmine-core": {
       "version": "5.1.1",
       "dev": true,
@@ -7473,6 +7479,7 @@
         "copyfiles": "^2.4.1",
         "eslint": "^8.56.0",
         "jasmine": "^4.5.0",
+        "jasmine-ajax": "^4.0.0",
         "karma": "^6.4.1",
         "karma-chrome-launcher": "^3.1.1",
         "karma-coverage": "^2.2.1",
@@ -10938,6 +10945,12 @@
         }
       }
     },
+    "jasmine-ajax": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-ajax/-/jasmine-ajax-4.0.0.tgz",
+      "integrity": "sha512-htTxNw38BSHxxmd8RRMejocdPqLalGHU6n3HWFbzp/S8AuTQd1MYjkSH3dYDsbZ7EV1Xqx/b94m3tKaVSVBV2A==",
+      "dev": true
+    },
     "jasmine-core": {
       "version": "5.1.1",
       "dev": true,
@@ -11283,6 +11296,7 @@
         "eslint": "^8.56.0",
         "handlebars": "^4.7.7",
         "jasmine": "^4.5.0",
+        "jasmine-ajax": "*",
         "jquery": "^3.6.0",
         "jszip": "^3.10.1",
         "karma": "^6.4.1",

--- a/platform/package.json
+++ b/platform/package.json
@@ -17,6 +17,7 @@
     "copyfiles": "^2.4.1",
     "eslint": "^8.56.0",
     "jasmine": "^4.5.0",
+    "jasmine-ajax": "^4.0.0",
     "karma": "^6.4.1",
     "karma-chrome-launcher": "^3.1.1",
     "karma-coverage": "^2.2.1",

--- a/platform/src/ToolsManager.js
+++ b/platform/src/ToolsManager.js
@@ -183,7 +183,7 @@ class ToolManager {
     /**
      * Find a panel definition by id
      * @param {string} panelDefId 
-     * @returns {PanelDefinition|null} the found panel definition  
+     * @returns {Object|null} the found panel definition  
      */
     getPanelDefinition(panelDefId) {
 

--- a/platform/test/spec/testToolManagerSpec.js
+++ b/platform/test/spec/testToolManagerSpec.js
@@ -1,18 +1,185 @@
+/*global describe, it, expect, spyOn, beforeEach, afterEach --  functions provided by Jasmine */
+/*global jasmine --  object provided by Jasmine */
 
-import {ToolManager} from "../../src/ToolsManager.js"
-
+import { ToolManager } from "../../src/ToolsManager.js";
+import { TOOL_1PANELDEF_1FUNCTION } from "../resources/TestToolFiles.js";
+import "jasmine-ajax"
 
 describe("ToolManager", () => {
 
+    describe("constructor", () => {
         it("can be created", () => {
-        
-                var tm = new ToolManager(["test-url"]);
-                
-                var tmType = typeof tm;
-                
-                expect(tmType).toBe("object");
-        
+            // Call the target object
+            let tm = new ToolManager();
+
+            // Check the expected results
+            expect(tm).toBeInstanceOf(ToolManager);
         })
-        
+    })
+
+    describe("initialisation", () => {
+         // Setup
+        const TOOL_URLS= [ "test://t1.url/tool-config.json" ];
+        let tm;
+
+        beforeEach( () => {
+            jasmine.Ajax.install();
+           
+            spyOn(XMLHttpRequest.prototype, "open").and.callThrough();
+            spyOn(XMLHttpRequest.prototype, "send").and.callThrough();
+
+            tm = new ToolManager();
+        })
+
+        afterEach(function() {
+            jasmine.Ajax.uninstall();
+        });
+         
+        it("tools URLs can be set", () => {
+            // Call the target object
+            tm.setToolsUrls(TOOL_URLS);
+
+            // Check the expected results
+            for (const t in tm.toolsUrls){
+                expect(tm.toolsUrls[t].url).toEqual(TOOL_URLS[t]);
+            }
+        })
+
+        it("the tool configuration is fetched from the remote given by its URL", () => {
+            // Call the target object
+            tm.setToolsUrls(TOOL_URLS);
+
+            // Check the expected results
+            expect(XMLHttpRequest.prototype.open).toHaveBeenCalledWith("GET", TOOL_URLS[0],false);
+        })
+
+        it("the tool configuration is parsed and stored", () => {
+            jasmine.Ajax.stubRequest('test://t1.url/tool-config.json').andReturn({
+                "responseText": TOOL_1PANELDEF_1FUNCTION,
+                "status": 200
+            });
+
+            // Call the target object
+            tm.setToolsUrls(TOOL_URLS);
+
+            // Check the expected results
+            const TOOL1_ID= "tool-1"
+
+            expect(tm.tools[TOOL1_ID]).toBeInstanceOf(Object);
+        })
+
+        it("the tool configuration that is parsed and stored has the expected keys", () => {
+            jasmine.Ajax.stubRequest('test://t1.url/tool-config.json').andReturn({
+                "responseText": TOOL_1PANELDEF_1FUNCTION,
+                "status": 200
+            });
+
+            // Call the target object
+            tm.setToolsUrls(TOOL_URLS);
+
+            // Check the expected results
+            const TOOL1_ID= "tool-1"
+            const EXPECTED_TOOL_KEYS = ["id", "name","version", "author", "homepage", "functions", "panelDefs"];
+
+            const storedToolKeys = Object.keys(tm.tools[TOOL1_ID]);
+            for (let key of EXPECTED_TOOL_KEYS){
+                expect( storedToolKeys.find(n => n===key ) ).toEqual(key);
+            }
+        })
+    })
+
+    describe("panel definitions can be retrieved", () => {
+        // Setup
+        const TOOL_URLS= [ "test://t1.url/tool-config.json" ];
+        const PANEL_DEF_ID = "paneldef-t1";
+        let tm;
+
+        beforeEach( () => {
+            jasmine.Ajax.install();
+           
+            spyOn(XMLHttpRequest.prototype, "open").and.callThrough();
+            spyOn(XMLHttpRequest.prototype, "send").and.callThrough();
+
+            tm = new ToolManager();
+        })
+
+        afterEach(function() {
+            jasmine.Ajax.uninstall();
+        });  
+
+        it ("for a panel definition id that exists its object is returned", () => {
+            jasmine.Ajax.stubRequest('test://t1.url/tool-config.json').andReturn({
+                "responseText": TOOL_1PANELDEF_1FUNCTION,
+                "status": 200
+            });
+            tm.setToolsUrls(TOOL_URLS);
+
+            // Call the target object
+            const foundPanelDef= tm.getPanelDefinition(PANEL_DEF_ID);
+
+            // Check the expected results
+            expect(foundPanelDef).toBeInstanceOf(Object);
+            expect(foundPanelDef.id).toEqual(PANEL_DEF_ID);
+        })
+
+        it ("for a panel definition id that does not exist null is returned", () => {
+            jasmine.Ajax.stubRequest('test://t1.url/tool-config.json').andReturn({
+                "responseText": TOOL_1PANELDEF_1FUNCTION,
+                "status": 200
+            });
+            tm.setToolsUrls(TOOL_URLS);
+
+            // Call the target object
+            const foundPanelDef= tm.getPanelDefinition("X");
+
+            // Check the expected results
+            expect(foundPanelDef).toEqual(null)
+        })
     
+    })
+
+    describe("tool grammar import locations can be retrieved", () => {
+        // Setup
+        const TOOL_BASE_URL = "test://t1.url";
+        const TOOL_URL= TOOL_BASE_URL + "/tool-config.json";
+        const TOOL_LANGUAGE_NAME = "test";
+        let tm;
+
+        beforeEach( () => {
+            jasmine.Ajax.install();
+           
+            spyOn(XMLHttpRequest.prototype, "open").and.callThrough();
+            spyOn(XMLHttpRequest.prototype, "send").and.callThrough();
+
+            tm = new ToolManager();
+
+            jasmine.Ajax.stubRequest(TOOL_URL).andReturn({
+                "responseText": TOOL_1PANELDEF_1FUNCTION,
+                "status": 200
+            });
+
+            tm.setToolsUrls([TOOL_URL]);
+        })
+
+        afterEach(function() {
+            jasmine.Ajax.uninstall();
+        });  
+
+        it ("the ace grammar urls for a tool defined", () => {
+            // Call the target object
+            const grammarImports = tm.getToolsGrammarImports();
+
+            // Check the expected results
+            expect(grammarImports[0].url).toEqual( TOOL_BASE_URL + "/highlighting.js");
+        })
+
+
+        it ("the ace grammar module for a tool is defined", () => {
+            // Call the target object
+            const grammarImports = tm.getToolsGrammarImports();
+
+            // Check the expected results
+            expect(grammarImports[0].module).toEqual( "ace/mode/"+ TOOL_LANGUAGE_NAME);
+        })
+    })
 })

--- a/platform/test/spec/testToolManagerSpec.js
+++ b/platform/test/spec/testToolManagerSpec.js
@@ -19,7 +19,9 @@ describe("ToolManager", () => {
 
     describe("initialisation", () => {
          // Setup
-        const TOOL_URLS= [ "test://t1.url/tool-config.json" ];
+        const TOOL_URLS= [ "test://t1.url/tool-config.json",
+                           "test://t2.url/tool-config.json",
+                           "test://t3.url/tool-config.json" ];
         let tm;
 
         beforeEach( () => {
@@ -38,10 +40,12 @@ describe("ToolManager", () => {
         it("sets tools URLs correctly", () => {
             // Call the target object
             tm.setToolsUrls(TOOL_URLS);
-
+    
             // Check the expected results
-            for (const t in tm.toolsUrls){
-                expect(tm.toolsUrls[t].url).toEqual(TOOL_URLS[t]);
+            expect(tm.toolsUrls).toHaveSize(TOOL_URLS.length);
+            
+            for (const i in TOOL_URLS){
+                expect(tm.toolsUrls[i].url).toEqual(TOOL_URLS[i]);
             }
         })
 
@@ -66,19 +70,6 @@ describe("ToolManager", () => {
             const TOOL1_ID= "tool-1"
 
             expect(tm.tools[TOOL1_ID]).toBeInstanceOf(Object);
-        })
-
-        it("the tool configuration that is parsed and stored has the expected keys", () => {
-            jasmine.Ajax.stubRequest('test://t1.url/tool-config.json').andReturn({
-                "responseText": TOOL_1PANELDEF_1FUNCTION,
-                "status": 200
-            });
-
-            // Call the target object
-            tm.setToolsUrls(TOOL_URLS);
-
-            // Check the expected results
-            const TOOL1_ID= "tool-1"
             const EXPECTED_TOOL_KEYS = ["id", "name","version", "author", "homepage", "functions", "panelDefs"];
 
             const storedToolKeys = Object.keys(tm.tools[TOOL1_ID]);
@@ -118,8 +109,11 @@ describe("ToolManager", () => {
             const foundPanelDef= tm.getPanelDefinition(PANEL_DEF_ID);
 
             // Check the expected results
+            const toolConfig = JSON.parse(TOOL_1PANELDEF_1FUNCTION);
+            const expectedPanelDef = toolConfig.tool.panelDefs[0];
+
             expect(foundPanelDef).toBeInstanceOf(Object);
-            expect(foundPanelDef.id).toEqual(PANEL_DEF_ID);
+            expect(foundPanelDef).toEqual(expectedPanelDef);
         })
 
         it ("returns null for a panel definition id that does not exist", () => {

--- a/platform/test/spec/testToolManagerSpec.js
+++ b/platform/test/spec/testToolManagerSpec.js
@@ -35,7 +35,7 @@ describe("ToolManager", () => {
             jasmine.Ajax.uninstall();
         });
          
-        it("tools URLs can be set", () => {
+        it("sets tools URLs correctly", () => {
             // Call the target object
             tm.setToolsUrls(TOOL_URLS);
 
@@ -45,7 +45,7 @@ describe("ToolManager", () => {
             }
         })
 
-        it("the tool configuration is fetched from the remote given by its URL", () => {
+        it("fetches the tool configuration from the remote given by its URL", () => {
             // Call the target object
             tm.setToolsUrls(TOOL_URLS);
 
@@ -53,7 +53,7 @@ describe("ToolManager", () => {
             expect(XMLHttpRequest.prototype.open).toHaveBeenCalledWith("GET", TOOL_URLS[0],false);
         })
 
-        it("the tool configuration is parsed and stored", () => {
+        it("parses and stores the tool configuration", () => {
             jasmine.Ajax.stubRequest('test://t1.url/tool-config.json').andReturn({
                 "responseText": TOOL_1PANELDEF_1FUNCTION,
                 "status": 200
@@ -88,7 +88,7 @@ describe("ToolManager", () => {
         })
     })
 
-    describe("panel definitions can be retrieved", () => {
+    describe("panel definitions", () => {
         // Setup
         const TOOL_URLS= [ "test://t1.url/tool-config.json" ];
         const PANEL_DEF_ID = "paneldef-t1";
@@ -107,7 +107,7 @@ describe("ToolManager", () => {
             jasmine.Ajax.uninstall();
         });  
 
-        it ("for a panel definition id that exists its object is returned", () => {
+        it ("returns the correct object for an existing panel definition id", () => {
             jasmine.Ajax.stubRequest('test://t1.url/tool-config.json').andReturn({
                 "responseText": TOOL_1PANELDEF_1FUNCTION,
                 "status": 200
@@ -122,7 +122,7 @@ describe("ToolManager", () => {
             expect(foundPanelDef.id).toEqual(PANEL_DEF_ID);
         })
 
-        it ("for a panel definition id that does not exist null is returned", () => {
+        it ("returns null for a panel definition id that does not exist", () => {
             jasmine.Ajax.stubRequest('test://t1.url/tool-config.json').andReturn({
                 "responseText": TOOL_1PANELDEF_1FUNCTION,
                 "status": 200
@@ -138,7 +138,7 @@ describe("ToolManager", () => {
     
     })
 
-    describe("tool grammar import locations can be retrieved", () => {
+    describe("tool grammar imports", () => {
         // Setup
         const TOOL_BASE_URL = "test://t1.url";
         const TOOL_URL= TOOL_BASE_URL + "/tool-config.json";
@@ -165,7 +165,7 @@ describe("ToolManager", () => {
             jasmine.Ajax.uninstall();
         });  
 
-        it ("the ace grammar urls for a tool defined", () => {
+        it ("correctly loads the URL of the ace grammar for a defined tool", () => {
             // Call the target object
             const grammarImports = tm.getToolsGrammarImports();
 
@@ -174,7 +174,7 @@ describe("ToolManager", () => {
         })
 
 
-        it ("the ace grammar module for a tool is defined", () => {
+        it ("correctly loads the ace grammar module for a defined tool", () => {
             // Call the target object
             const grammarImports = tm.getToolsGrammarImports();
 


### PR DESCRIPTION
Unit tests for ToolManager: constructor, initialisation, and getting grammar imports.

Updated comment in ToolsManager to reflect the actual returned type.

Added jasmine-ajax to development dependencies to enable testing of calls to `XMLHttpRequest`.

Code coverage for the module 72%.