### PR TITLE
Tests for config validators

### DIFF
--- a/platform/test/resources/TestActivityFiles.js
+++ b/platform/test/resources/TestActivityFiles.js
@@ -22,7 +22,17 @@ export const ACTIVITY_2PANELS_1ACTION = `{
                     "id": "panel-2",
                     "name": "Panel 2",
                     "ref": "paneldef-t1",
-                    "file": "file2.ext"
+                    "file": "file2.ext",
+                    "buttons": [
+                        {
+                            "id": "panel-button-1",
+                            "icon": "icon",
+                            "actionfunction": "function-1"
+                        },
+                        {
+                            "ref": "action-button"
+                        }
+                    ]
                 }
             ],
             "actions": [

--- a/platform/test/resources/TestUtility.js
+++ b/platform/test/resources/TestUtility.js
@@ -19,8 +19,8 @@ export function configObjectEquals(configA, configB){
 export const customMatchers = {
     
     /**
-     * Matcher to check the expected keywords are present in the give input.
-     * where actual is a Sting and expected is an array of strings that contains 
+     * Matcher to check the expected keywords are present in the given input.
+     * where actual is a String and expected is an array of strings that contains 
      * the keyword to check.
      */
     toContainKeywords : function(matchersUtil){

--- a/platform/test/resources/TestUtility.js
+++ b/platform/test/resources/TestUtility.js
@@ -31,8 +31,7 @@ export const customMatchers = {
                 };
 
                 // Check the condition
-                let containedResults =  expected.map( (akeyword)=> matchersUtil.contains(actual, akeyword) )
-                result.pass = containedResults.every(r => r);
+                result.pass = expected.every( (akeyword)=> matchersUtil.contains(actual, akeyword) );
 
                 if (result.pass){
                     result.message= `Expected the input to contain none of the keywords '${expected.toString()}' however at least one was found. input: '${actual}'`; // Negated not case

--- a/platform/test/resources/TestUtility.js
+++ b/platform/test/resources/TestUtility.js
@@ -1,3 +1,6 @@
+/*global expect --  functions provided by Jasmine */
+import { ConfigValidationError } from "../../src/ConfigValidationError.js";
+
 /**
  * Compares two configuration objects. 
  * @param {Object} configA
@@ -10,4 +13,51 @@ export function configObjectEquals(configA, configB){
     const strConfigB = JSON.stringify(configB);
 
     return (strConfigA === strConfigB)
+}
+
+export const customMatchers = {
+    toContainKeywords : function(matchersUtil){
+        return {
+            compare: function(actual, expected){
+
+                const result = {
+                };
+
+                // Check the condition
+                let containedResults =  expected.map( (akeyword)=> matchersUtil.contains(actual, akeyword) )
+                result.pass = containedResults.every(r => r);
+
+                if (result.pass){
+                    result.message= "test"; // Negated not case
+                } else {
+                    result.message= `Expected the input to contain all of the keywords '${expected.toString()}' however at least one was missing. input: '${actual}'`;
+                } 
+
+                return result;
+            } 
+        }
+    }
+}
+
+/**
+ * Checks a ConfigValidationError contains the expected content. For use in jasmine unit tests.
+ * 
+ * @param {ConfigValidationError} error - The error instance to check
+ * @param {String} category - The expected category text
+ * @param {String} type - The expected type text
+ * @param {Array<String>} messageKeywords - The expected keywords that must be present in the error message
+ * @param {String} location - The expected location text
+ */
+export function checkErrorPopulated(error, category, type, messageKeywords, location){
+    const MIN_LENGTH = 3;
+    expect(error).toBeInstanceOf(ConfigValidationError);
+    
+    expect(error.category.length).toBeGreaterThanOrEqual(MIN_LENGTH);
+    expect(error.message.length).toBeGreaterThanOrEqual(MIN_LENGTH);
+    expect(error.location.length).toBeGreaterThanOrEqual(MIN_LENGTH);
+   
+    expect(error.category).toEqual(category);
+    expect(error.fileType).toEqual(type);
+    expect(error.message).toContainKeywords(messageKeywords);
+    expect(error.location).toEqual(location);
 }

--- a/platform/test/resources/TestUtility.js
+++ b/platform/test/resources/TestUtility.js
@@ -15,7 +15,14 @@ export function configObjectEquals(configA, configB){
     return (strConfigA === strConfigB)
 }
 
+// Jasmine custom matchers
 export const customMatchers = {
+    
+    /**
+     * Matcher to check the expected keywords are present in the give input.
+     * where actual is a Sting and expected is an array of strings that contains 
+     * the keyword to check.
+     */
     toContainKeywords : function(matchersUtil){
         return {
             compare: function(actual, expected){
@@ -28,7 +35,7 @@ export const customMatchers = {
                 result.pass = containedResults.every(r => r);
 
                 if (result.pass){
-                    result.message= "test"; // Negated not case
+                    result.message= `Expected the input to contain none of the keywords '${expected.toString()}' however at least one was found. input: '${actual}'`; // Negated not case
                 } else {
                     result.message= `Expected the input to contain all of the keywords '${expected.toString()}' however at least one was missing. input: '${actual}'`;
                 } 

--- a/platform/test/resources/TestUtility.js
+++ b/platform/test/resources/TestUtility.js
@@ -23,7 +23,7 @@ export const customMatchers = {
      * where actual is a String and expected is an array of strings that contains 
      * the keyword to check.
      */
-    toContainKeywords : function(matchersUtil){
+    toContainAllKeywords : function(matchersUtil){
         return {
             compare: function(actual, expected){
 
@@ -65,6 +65,6 @@ export function checkErrorPopulated(error, category, type, messageKeywords, loca
    
     expect(error.category).toEqual(category);
     expect(error.fileType).toEqual(type);
-    expect(error.message).toContainKeywords(messageKeywords);
+    expect(error.message).toContainAllKeywords(messageKeywords);
     expect(error.location).toEqual(location);
 }

--- a/platform/test/spec/testActivityConfigValidatorSpec.js
+++ b/platform/test/spec/testActivityConfigValidatorSpec.js
@@ -1,8 +1,7 @@
-/*global describe, it, expect, beforeEach --  functions provided by Jasmine */
+/*global describe, it, expect, beforeEach, jasmine --  functions provided by Jasmine */
 import { ActivityConfigValidator } from "../../src/ActivityConfigValidator.js"
 import { ACTIVITY_2PANELS_1ACTION } from "../resources/TestActivityFiles.js";
-import { ConfigValidationError } from "../../src/ConfigValidationError.js"
-
+import {customMatchers, checkErrorPopulated} from "../resources/TestUtility.js"
 
 const EXPECTED_FILE_TYPE = "ActivityConfig"; 
 
@@ -18,12 +17,13 @@ describe("ActivityConfigValidator", () => {
         })
     })
 
-    describe("validate tool configuration", () => {
+    describe("validate activity configuration", () => {
         let acv;
         let activityConfig;
         
         //Setup
         beforeEach( () => {
+            jasmine.addMatchers(customMatchers);
             activityConfig = JSON.parse(ACTIVITY_2PANELS_1ACTION);
             acv = new ActivityConfigValidator();
         })
@@ -36,18 +36,9 @@ describe("ActivityConfigValidator", () => {
             expect(errors).toHaveSize(0);
         })
 
-        it("returns errors that are  ConfigValidationError instances",() => {
-            delete activityConfig.activities[0].id;
-
-            // Call the target object
-            let errors = acv.validateConfigFile(activityConfig);
-            let e = errors[0];
-            
-            // Check the expected results
-            expect(e).toBeInstanceOf(ConfigValidationError);
-            expect(e.fileType).toEqual(EXPECTED_FILE_TYPE);
-        })
-
+        /*--------------------------------------------------------
+         *   Activity
+         *--------------------------------------------------------*/
         it("returns an error if the config has no id key", () => {
             delete activityConfig.activities[0].id;
 
@@ -57,9 +48,138 @@ describe("ActivityConfigValidator", () => {
             
             // Check the expected results
             expect(errors).toHaveSize(1);
-            checkErrorPopulated(e);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "id"], "/activities/0");
         })
 
+        it("returns an error if the config has no title key", () => {
+            delete activityConfig.activities[0].title;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "title"], "/activities/0");
+        })
+
+        it("returns an error if the config has no tools key", () => {
+            delete activityConfig.activities[0].tools;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "tools"], "/activities/0");
+        })
+
+        it("returns an error if the config has no layout key", () => {
+            delete activityConfig.activities[0].layout;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "layout"], "/activities/0");
+        })
+
+        it("returns an error if the config has no actions key", () => {
+            delete activityConfig.activities[0].actions;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "actions"], "/activities/0");
+        })
+
+        it("returns an error if the config has no panels key", () => {
+            delete activityConfig.activities[0].panels;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "panels"], "/activities/0");
+        })
+
+        /*--------------------------------------------------------
+         *   Layout
+         *--------------------------------------------------------*/
+        it("returns an error if the config layout has no area key", () => {
+            delete activityConfig.activities[0].layout.area;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "area"], "/activities/0/layout");
+        })
+        
+        /*--------------------------------------------------------
+         *   Actions
+         *--------------------------------------------------------*/
+        it("returns an error if a config action has no source key", () => {
+            delete activityConfig.activities[0].actions[0].source;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "source"], "/activities/0/actions/0");
+        })
+
+        it("returns an error if a config action has no sourceButton key", () => {
+            delete activityConfig.activities[0].actions[0].sourceButton;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "sourceButton"], "/activities/0/actions/0");
+        })
+
+        it("returns an error if a config action has no parameters key", () => {
+            delete activityConfig.activities[0].actions[0].parameters;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "parameters"], "/activities/0/actions/0");
+        })
+
+        it("returns an error if a config action has no output key", () => {
+            delete activityConfig.activities[0].actions[0].output;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "output"], "/activities/0/actions/0");
+        })
+
+        /*--------------------------------------------------------
+         *   Panels
+         *--------------------------------------------------------*/
         it("returns an error if a panel in config has no id key", () => {
             delete activityConfig.activities[0].panels[1].id;
 
@@ -69,16 +189,74 @@ describe("ActivityConfigValidator", () => {
             
             // Check the expected results
             expect(errors).toHaveSize(1);
-            checkErrorPopulated(e);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "id"], "/activities/0/panels/1");
+        })
+
+        it("returns an error if a panel in config has no name key", () => {
+            delete activityConfig.activities[0].panels[1].name;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "name"], "/activities/0/panels/1");
+        })
+
+        it("returns an error if a panel in config has no ref key", () => {
+            delete activityConfig.activities[0].panels[1].ref;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "ref"], "/activities/0/panels/1");
+        })
+
+        /* ---- Buttons ----  */
+        it("returns an error if a panel button in config has no id key", () => {
+            delete activityConfig.activities[0].panels[1].buttons[0].id;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(3); // As Json schema oneOf is used to allow either ref or a button so a ref error 
+                                          // and oneOf error are also returned
+
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "id"], "/activities/0/panels/1/buttons/0");
+        })
+
+        it("returns an error if a panel button in config has no icon key", () => {
+            delete activityConfig.activities[0].panels[1].buttons[0].icon;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(3); // As Json schema oneOf is used to allow either ref or a button so a ref 
+                                          // and oneOf errors are also returned
+
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "icon"], "/activities/0/panels/1/buttons/0");
+        })
+
+        it("returns an error if a panel button ref in config has no ref key", () => {
+            delete activityConfig.activities[0].panels[1].buttons[1].ref;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[2];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(4); // As Json schema oneOf is used to allow either ref or a button so a button  
+                                          // and oneOf errors are also returned
+
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "ref"], "/activities/0/panels/1/buttons/1");
         })
     }) 
 })
-
-function checkErrorPopulated(error){
-    const MIN_LENGTH = 3;
-    expect(error).toBeInstanceOf(ConfigValidationError);
-    expect(error.fileType).toEqual(EXPECTED_FILE_TYPE);
-    expect(error.location.length).toBeGreaterThanOrEqual(MIN_LENGTH);
-    expect(error.category.length).toBeGreaterThanOrEqual(MIN_LENGTH);
-    expect(error.message.length).toBeGreaterThanOrEqual(MIN_LENGTH);
-}

--- a/platform/test/spec/testActivityConfigValidatorSpec.js
+++ b/platform/test/spec/testActivityConfigValidatorSpec.js
@@ -18,7 +18,7 @@ describe("ActivityConfigValidator", () => {
         })
     })
 
-    describe("validate tool configration", () => {
+    describe("validate tool configuration", () => {
         let acv;
         let activityConfig;
         

--- a/platform/test/spec/testActivityConfigValidatorSpec.js
+++ b/platform/test/spec/testActivityConfigValidatorSpec.js
@@ -1,0 +1,84 @@
+/*global describe, it, expect, beforeEach --  functions provided by Jasmine */
+import { ActivityConfigValidator } from "../../src/ActivityConfigValidator.js"
+import { ACTIVITY_2PANELS_1ACTION } from "../resources/TestActivityFiles.js";
+import { ConfigValidationError } from "../../src/ConfigValidationError.js"
+
+
+const EXPECTED_FILE_TYPE = "ActivityConfig"; 
+
+describe("ActivityConfigValidator", () => {
+      
+    describe("constructor", () => {
+        it("can be created", () => {
+            // Call the target object
+            let acv = new ActivityConfigValidator();
+            
+            // Check the expected results
+            expect(acv).toBeInstanceOf(ActivityConfigValidator);
+        })
+    })
+
+    describe("validate tool configration", () => {
+        let acv;
+        let activityConfig;
+        
+        //Setup
+        beforeEach( () => {
+            activityConfig = JSON.parse(ACTIVITY_2PANELS_1ACTION);
+            acv = new ActivityConfigValidator();
+        })
+
+        it("reports no errors for a valid config", () => {
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            
+            // Check the expected results
+            expect(errors).toHaveSize(0);
+        })
+
+        it("returns errors that are  ConfigValidationError instances",() => {
+            delete activityConfig.activities[0].id;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(e).toBeInstanceOf(ConfigValidationError);
+            expect(e.fileType).toEqual(EXPECTED_FILE_TYPE);
+        })
+
+        it("returns an error if the config has no id key", () => {
+            delete activityConfig.activities[0].id;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e);
+        })
+
+        it("returns an error if a panel in config has no id key", () => {
+            delete activityConfig.activities[0].panels[1].id;
+
+            // Call the target object
+            let errors = acv.validateConfigFile(activityConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e);
+        })
+    }) 
+})
+
+function checkErrorPopulated(error){
+    const MIN_LENGTH = 3;
+    expect(error).toBeInstanceOf(ConfigValidationError);
+    expect(error.fileType).toEqual(EXPECTED_FILE_TYPE);
+    expect(error.location.length).toBeGreaterThanOrEqual(MIN_LENGTH);
+    expect(error.category.length).toBeGreaterThanOrEqual(MIN_LENGTH);
+    expect(error.message.length).toBeGreaterThanOrEqual(MIN_LENGTH);
+}

--- a/platform/test/spec/testToolConfigValidatorSpec.js
+++ b/platform/test/spec/testToolConfigValidatorSpec.js
@@ -1,8 +1,7 @@
-/*global describe, it, expect, beforeEach --  functions provided by Jasmine */
-import { ToolConfigValidator } from "../../src/ToolConfigValidator"
+/*global describe, it, expect, beforeEach, jasmine --  functions provided by Jasmine */
+import { ToolConfigValidator } from "../../src/ToolConfigValidator";
 import { TOOL_1PANELDEF_1FUNCTION } from "../resources/TestToolFiles.js";
-import { ConfigValidationError } from "../../src/ConfigValidationError.js"
-
+import {customMatchers, checkErrorPopulated} from "../resources/TestUtility.js"
 
 const EXPECTED_FILE_TYPE = "ToolConfig"; 
 
@@ -24,6 +23,7 @@ describe("ToolConfigValidator", () => {
         
         //Setup
         beforeEach( () => {
+            jasmine.addMatchers(customMatchers);
             toolConfig = JSON.parse(TOOL_1PANELDEF_1FUNCTION);
             tcv = new ToolConfigValidator();
         })
@@ -36,18 +36,9 @@ describe("ToolConfigValidator", () => {
             expect(errors).toHaveSize(0);
         })
 
-        it("returns errors that are ConfigValidationError instances",() => {
-            delete toolConfig.tool.id;
-
-            // Call the target object
-            let errors = tcv.validateConfigFile(toolConfig);
-            let e = errors[0];
-            
-            // Check the expected results
-            expect(e).toBeInstanceOf(ConfigValidationError);
-            expect(e.fileType).toEqual(EXPECTED_FILE_TYPE);
-        })
-
+        /*--------------------------------------------------------
+         *   Tool
+         *--------------------------------------------------------*/
         it("returns an error if the config has no id key", () => {
             delete toolConfig.tool.id;
 
@@ -57,7 +48,31 @@ describe("ToolConfigValidator", () => {
             
             // Check the expected results
             expect(errors).toHaveSize(1);
-            checkErrorPopulated(e);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "id"], "/tool");
+        })
+
+        it("returns an error if the config has no name key", () => {
+            delete toolConfig.tool.name;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "name"], "/tool");
+        })
+
+        it("returns an error if the config has no functions key", () => {
+            delete toolConfig.tool.functions;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "functions"], "/tool");
         })
 
         it("returns an error if a panel definition in the config has no id key", () => {
@@ -69,16 +84,161 @@ describe("ToolConfigValidator", () => {
             
             // Check the expected results
             expect(errors).toHaveSize(1);
-            checkErrorPopulated(e);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "id"], "/tool/panelDefs/0");
         })
+
+        /*--------------------------------------------------------
+         *   Panel Definitions
+         *--------------------------------------------------------*/
+        it("returns an error if a panel definition in the config has no name key", () => {
+            delete toolConfig.tool.panelDefs[0].name;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "name"], "/tool/panelDefs/0");
+        })
+
+        it("returns an error if a panel definition in the config has no panelclass key", () => {
+            delete toolConfig.tool.panelDefs[0].panelclass;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "panelclass"], "/tool/panelDefs/0");
+        })
+
+        it("returns an error if a panel definition in the config has no icon key", () => {
+            delete toolConfig.tool.panelDefs[0].icon;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "icon"], "/tool/panelDefs/0");
+        })
+
+        /* ---- Buttons ----  */
+        it("returns an error if a button in the config has no id key", () => {
+            delete toolConfig.tool.panelDefs[0].buttons[0].id;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "id"], "/tool/panelDefs/0/buttons/0");
+        }) 
+
+        it("returns an error if a button in the config has no id key", () => {
+            delete toolConfig.tool.panelDefs[0].buttons[0].icon;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "icon"], "/tool/panelDefs/0/buttons/0");
+        }) 
+
+
+        /*--------------------------------------------------------
+         *   Functions
+         *--------------------------------------------------------*/
+        it("returns an error if a function in the config has no id key", () => {
+            delete toolConfig.tool.functions[0].id;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "id"], "/tool/functions/0");
+        }) 
+
+        it("returns an error if a function in the config has no name key", () => {
+            delete toolConfig.tool.functions[0].name;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "name"], "/tool/functions/0");
+        }) 
+
+        it("returns an error if a function in the config has no parameters key", () => {
+            delete toolConfig.tool.functions[0].parameters;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "parameters"], "/tool/functions/0");
+        }) 
+        
+        it("returns an error if a function in the config has no returnType key", () => {
+            delete toolConfig.tool.functions[0].returnType;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "returnType"], "/tool/functions/0");
+        })
+        
+        it("returns an error if a function in the config has no path key", () => {
+            delete toolConfig.tool.functions[0].path;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "path"], "/tool/functions/0");
+        }) 
+
+        /* ---- Parameters ----  */
+        it("returns an error if a parameter in the config has no name key", () => {
+            delete toolConfig.tool.functions[0].parameters[1].name;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "name"], "/tool/functions/0/parameters/1");
+        })
+        
+        it("returns an error if a parameter in the config has no type key", () => {
+            delete toolConfig.tool.functions[0].parameters[1].type;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e, "required", EXPECTED_FILE_TYPE, ["required", "type"], "/tool/functions/0/parameters/1");
+        }) 
     }) 
 })
 
-function checkErrorPopulated(error){
-    const MIN_LENGTH = 3;
-    expect(error).toBeInstanceOf(ConfigValidationError);
-    expect(error.fileType).toEqual(EXPECTED_FILE_TYPE);
-    expect(error.location.length).toBeGreaterThanOrEqual(MIN_LENGTH);
-    expect(error.category.length).toBeGreaterThanOrEqual(MIN_LENGTH);
-    expect(error.message.length).toBeGreaterThanOrEqual(MIN_LENGTH);
-}

--- a/platform/test/spec/testToolConfigValidatorSpec.js
+++ b/platform/test/spec/testToolConfigValidatorSpec.js
@@ -1,0 +1,84 @@
+/*global describe, it, expect, beforeEach --  functions provided by Jasmine */
+import { ToolConfigValidator } from "../../src/ToolConfigValidator"
+import { TOOL_1PANELDEF_1FUNCTION } from "../resources/TestToolFiles.js";
+import { ConfigValidationError } from "../../src/ConfigValidationError.js"
+
+
+const EXPECTED_FILE_TYPE = "ToolConfig"; 
+
+describe("ToolConfigValidator", () => {
+      
+    describe("constructor", () => {
+        it("can be created", () => {
+            // Call the target object
+            let tcv = new ToolConfigValidator();
+            
+            // Check the expected results
+            expect(tcv).toBeInstanceOf(ToolConfigValidator);
+        })
+    })
+
+    describe("validate tool configration", () => {
+        let tcv;
+        let toolConfig;
+        
+        //Setup
+        beforeEach( () => {
+            toolConfig = JSON.parse(TOOL_1PANELDEF_1FUNCTION);
+            tcv = new ToolConfigValidator();
+        })
+
+        it("reports no errors for a valid config", () => {
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            
+            // Check the expected results
+            expect(errors).toHaveSize(0);
+        })
+
+        it("returns errors that are ConfigValidationError instances",() => {
+            delete toolConfig.tool.id;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(e).toBeInstanceOf(ConfigValidationError);
+            expect(e.fileType).toEqual(EXPECTED_FILE_TYPE);
+        })
+
+        it("returns an error if the config has no id key", () => {
+            delete toolConfig.tool.id;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e);
+        })
+
+        it("returns an error if a panel definition in the config has no id key", () => {
+            delete toolConfig.tool.panelDefs[0].id;
+
+            // Call the target object
+            let errors = tcv.validateConfigFile(toolConfig);
+            let e = errors[0];
+            
+            // Check the expected results
+            expect(errors).toHaveSize(1);
+            checkErrorPopulated(e);
+        })
+    }) 
+})
+
+function checkErrorPopulated(error){
+    const MIN_LENGTH = 3;
+    expect(error).toBeInstanceOf(ConfigValidationError);
+    expect(error.fileType).toEqual(EXPECTED_FILE_TYPE);
+    expect(error.location.length).toBeGreaterThanOrEqual(MIN_LENGTH);
+    expect(error.category.length).toBeGreaterThanOrEqual(MIN_LENGTH);
+    expect(error.message.length).toBeGreaterThanOrEqual(MIN_LENGTH);
+}

--- a/platform/test/spec/testToolConfigValidatorSpec.js
+++ b/platform/test/spec/testToolConfigValidatorSpec.js
@@ -18,7 +18,7 @@ describe("ToolConfigValidator", () => {
         })
     })
 
-    describe("validate tool configration", () => {
+    describe("validate tool configuration", () => {
         let tcv;
         let toolConfig;
         


### PR DESCRIPTION
Tests for ToolConfigValidator and ActivityConfigValidator.

Code coverage for the modules 100% though further tests can be added to check the contents of each error message against the error raised.
