### PR TITLE
Fix only provide parameters used by tool functions

### DIFF
--- a/platform/src/EducationPlatformApp.js
+++ b/platform/src/EducationPlatformApp.js
@@ -491,11 +491,7 @@ class EducationPlatformApp {
 
                     const panelConfig = parameterMap.get(param.name); 
 
-                    if (panelConfig == undefined){
-                        // Set unused parameters in the request to undefined as the epsilon backend function expects them all. 
-                        actionRequestData[param.name] = "undefined";
-
-                    } else {
+                    if (panelConfig != undefined){
                         let parameterData = values.find(val => (val.name === param.name) );
 
                         actionRequestData[param.name] =  parameterData.data;

--- a/platform/test/spec/testEducationPlatformAppSpec.js
+++ b/platform/test/spec/testEducationPlatformAppSpec.js
@@ -296,9 +296,7 @@ describe("EducationPlatformApp", () => {
             expect(platform.functionRegistry_call).toHaveBeenCalledWith(ACTION_FUNCTION_ID, EXPECTED_PARAM_VALUES);
         })
         
-        it("sends request to a conversion function's url with unused parameters set to undefined", async () => {
-            /* This behaviour was to ensure compatibility with java google cloud function based
-             * Epsilon playground pre Micronaut that required all parameters to be provided. */
+        it("sends requests to a conversion function's url without unused parameters", async () => {
             const PARAM1_TYPE = ACTION_FUNCTION_PARAM1_TYPE;
 
             const parameterMap = new Map (
@@ -323,7 +321,6 @@ describe("EducationPlatformApp", () => {
             // Check the expected results
             const EXPECTED_PARAM_VALUES = {
                 [PARAM1_NAME]: PARAM1_VALUE,
-                [PARAM2_NAME]: "undefined",
                 "language": TOOL_LANGUAGE
             }
             


### PR DESCRIPTION
Modified invokeActionFunction() to not populate unused parameters as 'undefined' because this is no longer necessary when using the Epsilon micronaut tool service.

Along https://github.com/epsilonlabs/playground-micronaut/pull/4 with fixes #41 

Mentioned in code review for PR https://github.com/mdenet/educationplatform/pull/198#discussion_r1531961177