### PR TITLE
Fix errors on resize

### DIFF
--- a/platform/src/EducationPlatformApp.js
+++ b/platform/src/EducationPlatformApp.js
@@ -30,7 +30,7 @@ import { CompositePanel } from './CompositePanel.js';
 import { Button } from './Button.js';
 
 import { Preloader } from './Preloader.js';
-import { Layout } from './Layout.js';
+import { Layout, PANEL_HOLDER_ID } from './Layout.js';
 import { PlaygroundUtility } from './PlaygroundUtility.js';
 import { jsonRequest, urlParamPrivateRepo, utility } from './Utility.js';
 import { ErrorHandler } from './ErrorHandler.js';
@@ -532,7 +532,7 @@ class EducationPlatformApp {
 
 
     fit() {
-        var splitter = document.getElementById("splitter");
+        var splitter = document.getElementById(PANEL_HOLDER_ID);
         if (splitter){
             splitter.style.minHeight = window.innerHeight + "px";
             splitter.style.maxHeight = window.innerHeight + "px";

--- a/platform/src/EducationPlatformApp.js
+++ b/platform/src/EducationPlatformApp.js
@@ -532,11 +532,11 @@ class EducationPlatformApp {
 
 
     fit() {
-        
         var splitter = document.getElementById("splitter");
-        splitter.style.minHeight = window.innerHeight + "px";
-        splitter.style.maxHeight = window.innerHeight + "px";
-
+        if (splitter){
+            splitter.style.minHeight = window.innerHeight + "px";
+            splitter.style.maxHeight = window.innerHeight + "px";
+        }
         this.panels.forEach(panel => panel.fit());
         this.preloader.hide();
     }

--- a/platform/src/Layout.js
+++ b/platform/src/Layout.js
@@ -15,7 +15,7 @@ class Layout {
         var splitter;
 
         if ( panels.length == 1 ) {
-            splitter = Layout.createVerticalSplitter([panels[0].getElement()]);
+            splitter = panels[0].getElement(); // only the element to add
 
         } else if ( panels.length == 2  ) {
             splitter = Layout.createVerticalSplitter([panels[0].getElement(), panels[1].getElement()], "50, 50" );
@@ -36,7 +36,7 @@ class Layout {
 
             // Odd number of panels so add the last element
             if (panelsToLayout.length==1){
-                verticalSplitters.push( Layout.createVerticalSplitter([panelsToLayout.pop().getElement()]) );
+                verticalSplitters.push(panelsToLayout.pop().getElement());
             }
 
             splitter = Layout.createHorizontalSplitter( verticalSplitters, splitProportions);   

--- a/platform/src/Layout.js
+++ b/platform/src/Layout.js
@@ -89,7 +89,13 @@ class Layout {
 
             // Create the splitters for the row
             let splitProportions = ("10, ".repeat(numberOfRows)); // Add a proportion per splitter
-            verticalSplitters.push ( Layout.createVerticalSplitter( panelsToLayout.map( pn => pn.getElement() ), splitProportions) );
+
+            if (panelsToLayout.length > 1) {
+                verticalSplitters.push( Layout.createVerticalSplitter( panelsToLayout.map( pn => pn.getElement() ), splitProportions) );
+            } else {
+                // No splitter required for a single panel
+                verticalSplitters.push( panelsToLayout[0].getElement() );
+            }
         }
         
         if (numberOfColumns > 1) {

--- a/platform/src/Layout.js
+++ b/platform/src/Layout.js
@@ -1,3 +1,4 @@
+const PANEL_HOLDER_ID = "navview-content-panels";
 
 class Layout {
 
@@ -9,43 +10,49 @@ class Layout {
      */
     createFromPanels(rootId, panels){
 
+        if (panels == null || panels.length < 1){
+             // Nothing to do
+            return;
+        }
+
         var root = document.getElementById(rootId);
         root.innerHTML = "";
 
-        var splitter;
+        var panelHolderElement;
 
         if ( panels.length == 1 ) {
-            splitter = panels[0].getElement(); // only the element to add
-
-        } else if ( panels.length == 2  ) {
-            splitter = Layout.createVerticalSplitter([panels[0].getElement(), panels[1].getElement()], "50, 50" );
+            panelHolderElement = panels[0].getElement(); // only the element to add
 
         } else {
-            var panelsToLayout = [...panels];            
-            var numberOfVerticalSplitters= Math.floor(panels.length / 2 );
-            var verticalSplitters = [];
-            var splitProportions =  ("10, ".repeat(numberOfVerticalSplitters)).slice(0, -2);
+            if ( panels.length == 2  ) {
+                panelHolderElement = Layout.createVerticalSplitter([panels[0].getElement(), panels[1].getElement()], "50, 50" );
 
-            // Layout pairs of panels
-            for ( let sNo = 0; sNo < numberOfVerticalSplitters; sNo++) {
-                verticalSplitters.push( 
-                    // Appearance:                                Top               ,                  Bottom 
-                    Layout.createVerticalSplitter([panelsToLayout.pop().getElement(), panelsToLayout.pop().getElement()] ) 
-                ); 
+            } else {
+                var panelsToLayout = [...panels];
+                var numberOfVerticalSplitters= Math.floor(panels.length / 2 );
+                var verticalSplitters = [];
+                var splitProportions =  ("10, ".repeat(numberOfVerticalSplitters)).slice(0, -2);
+
+                // Layout pairs of panels
+                for ( let sNo = 0; sNo < numberOfVerticalSplitters; sNo++) {
+                    verticalSplitters.push(
+                        // Appearance:                                Top               ,                  Bottom
+                        Layout.createVerticalSplitter([panelsToLayout.pop().getElement(), panelsToLayout.pop().getElement()] ) 
+                    );
+                }
+
+                // Odd number of panels so add the last element
+                if (panelsToLayout.length==1){
+                    verticalSplitters.push(panelsToLayout.pop().getElement());
+                }
+
+                panelHolderElement = Layout.createHorizontalSplitter( verticalSplitters, splitProportions);
             }
-
-            // Odd number of panels so add the last element
-            if (panelsToLayout.length==1){
-                verticalSplitters.push(panelsToLayout.pop().getElement());
-            }
-
-            splitter = Layout.createHorizontalSplitter( verticalSplitters, splitProportions);   
         }
 
-        splitter.setAttribute("class", "h-100");
-        splitter.setAttribute("id", "splitter");
-        splitter.setAttribute("style", "min-height:800px");
-        root.appendChild(splitter);
+        Layout.addPanelHolderAttributes(panelHolderElement);
+
+        root.appendChild(panelHolderElement);
     }
 
 
@@ -62,8 +69,7 @@ class Layout {
         root.innerHTML = "";
 
         let verticalSplitters=[];
-        let splitter;
-
+        let panelHolderElement;
 
         // Get the number of rows and columns
         let numberOfRows = layout.length;
@@ -100,18 +106,26 @@ class Layout {
         
         if (numberOfColumns > 1) {
             let splitProportions =  ("10, ".repeat(verticalSplitters.length)); // Add a proportion per splitter
-            splitter = Layout.createHorizontalSplitter( verticalSplitters, splitProportions ); 
+            panelHolderElement = Layout.createHorizontalSplitter( verticalSplitters, splitProportions );
 
         } else {
             // No splitter for single columns
-            splitter = Layout.createVerticalSplitter( verticalSplitters) ;
+            panelHolderElement = verticalSplitters[0];
         } 
 
-        splitter.setAttribute("class", "h-100");
-        splitter.setAttribute("id", "splitter");
-        splitter.setAttribute("style", "min-height:800px");
+        Layout.addPanelHolderAttributes(panelHolderElement);
         
-        root.appendChild(splitter);
+        root.appendChild(panelHolderElement);
+    }
+
+    /**
+     * Add the panel holder attributes to the given element.
+     * @param {HTMLElement} holderElement - The HTML element to add the attributes to
+     */
+    static addPanelHolderAttributes(holderElement){
+        holderElement.setAttribute("class", "h-100");
+        holderElement.setAttribute("id", PANEL_HOLDER_ID);
+        holderElement.setAttribute("style", "min-height:800px");
     }
 
     static createHorizontalSplitter(components, split = "50, 50") {
@@ -137,4 +151,4 @@ class Layout {
 
 }
 
-export { Layout };
+export { Layout, PANEL_HOLDER_ID };

--- a/platform/src/Layout.js
+++ b/platform/src/Layout.js
@@ -23,31 +23,30 @@ class Layout {
         if ( panels.length == 1 ) {
             panelHolderElement = panels[0].getElement(); // only the element to add
 
-        } else {
-            if ( panels.length == 2  ) {
+        } else if ( panels.length == 2  ) {
                 panelHolderElement = Layout.createVerticalSplitter([panels[0].getElement(), panels[1].getElement()], "50, 50" );
 
-            } else {
-                var panelsToLayout = [...panels];
-                var numberOfVerticalSplitters= Math.floor(panels.length / 2 );
-                var verticalSplitters = [];
-                var splitProportions =  ("10, ".repeat(numberOfVerticalSplitters)).slice(0, -2);
+        } else {
+            // Three or more panels
+            var panelsToLayout = [...panels];
+            var numberOfVerticalSplitters= Math.floor(panels.length / 2 );
+            var verticalSplitters = [];
+            var splitProportions =  ("10, ".repeat(numberOfVerticalSplitters)).slice(0, -2);
 
-                // Layout pairs of panels
-                for ( let sNo = 0; sNo < numberOfVerticalSplitters; sNo++) {
-                    verticalSplitters.push(
-                        // Appearance:                                Top               ,                  Bottom
-                        Layout.createVerticalSplitter([panelsToLayout.pop().getElement(), panelsToLayout.pop().getElement()] ) 
-                    );
-                }
-
-                // Odd number of panels so add the last element
-                if (panelsToLayout.length==1){
-                    verticalSplitters.push(panelsToLayout.pop().getElement());
-                }
-
-                panelHolderElement = Layout.createHorizontalSplitter( verticalSplitters, splitProportions);
+            // Layout pairs of panels
+            for ( let sNo = 0; sNo < numberOfVerticalSplitters; sNo++) {
+                verticalSplitters.push(
+                    // Appearance:                                Top               ,                  Bottom
+                    Layout.createVerticalSplitter([panelsToLayout.pop().getElement(), panelsToLayout.pop().getElement()] ) 
+                );
             }
+
+            // Odd number of panels so add the last element
+            if (panelsToLayout.length==1){
+                verticalSplitters.push(panelsToLayout.pop().getElement());
+            }
+
+            panelHolderElement = Layout.createHorizontalSplitter( verticalSplitters, splitProportions);
         }
 
         Layout.addPanelHolderAttributes(panelHolderElement);


### PR DESCRIPTION
Fixed creation of panel splitters in Layout so that panel layouts with an odd number of panels do not have an unnecessary splitter that causes a Metro exception on page resize, and added defensive check for fit() when no splitters are found.