### PR TITLE
Add sendFullText option to XtextEditorPanel

### DIFF
--- a/platform/src/XtextEditorPanel.js
+++ b/platform/src/XtextEditorPanel.js
@@ -25,7 +25,8 @@ class XtextEditorPanel extends Panel {
                 enableCors: true,
                 syntaxDefinition: modeName,
                 parent: editorContainer,
-                xtextLang: extension
+                xtextLang: extension,
+                sendFullText: true // For some reason, otherwise the interaction with the generated editors breaks...
             });
         });
 


### PR DESCRIPTION
Added 'sendFullText' option to xtextLang configuration. This is to ensure automatically deployed instances run correctly on our servers across staging and production.